### PR TITLE
Feature/sidebar markup cleanup

### DIFF
--- a/course_flow/static/course_flow/js/react/dist/course_flow.css
+++ b/course_flow/static/course_flow/js/react/dist/course_flow.css
@@ -563,9 +563,6 @@ h3.big-space {
 .panel-item.active {
   background: #eefff8; }
 
-.panel-favourite.active {
-  background: #eefff8; }
-
 .panel-item > img,
 .panel-item .material-symbols-rounded {
   margin-right: 10px; }
@@ -575,17 +572,6 @@ h3.big-space {
 
 .panel-item img {
   width: 24px; }
-
-.panel-favourite {
-  padding: 3px;
-  font-size: 13px;
-  display: block;
-  margin-left: 22px;
-  margin-right: 20px;
-  overflow: hidden;
-  -webkit-line-clamp: 1;
-  display: -webkit-box;
-  -webkit-box-orient: vertical; }
 
 .left-panel hr {
   margin-bottom: 20px;

--- a/course_flow/static/course_flow/js/react/dist/scripts-library.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-library.min.js
@@ -41007,6 +41007,7 @@ var library_renderers = (function (exports) {
 	    if (this.state.favourite) fav_class = ' filled';
 	    let buttons = [];
 	    if (this.props.workflow_data.type !== 'liveproject') buttons.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "btn-workflow-toggle-favourite",
 	      className: "workflow-toggle-favourite hover-shade",
 	      onClick: evt => {
 	        toggleFavourite(this.props.workflow_data.id, this.props.workflow_data.type, !this.state.favourite);
@@ -41022,15 +41023,18 @@ var library_renderers = (function (exports) {
 	    }, "star")));
 	    let workflows = [];
 	    if (this.props.workflow_data.type === 'project' && !(this.props.workflow_data.workflow_count == null)) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "workflow-created-count",
 	      className: "workflow-created"
 	    }, this.props.workflow_data.workflow_count + ' ' + gettext('workflows')));
 	    if (this.props.workflow_data.type == 'project' && this.props.workflow_data.has_liveproject && this.props.workflow_data.object_permission.role_type !== role_keys['none']) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "workflow-created-group",
 	      className: "workflow-created workflow-live-classroom"
 	    }, /*#__PURE__*/reactExports.createElement("span", {
 	      className: "material-symbols-rounded small-inline",
 	      title: gettext('Live Classroom')
 	    }, "group"), ' ' + gettext('Live Classroom')));
 	    if (this.props.workflow_data.is_linked) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "workflow-created-warning",
 	      className: "workflow-created linked-workflow-warning",
 	      title: gettext('Warning: linking the same workflow to multiple nodes can result in loss of readability if you are associating parent workflow outcomes with child workflow outcomes.')
 	    }, /*#__PURE__*/reactExports.createElement("span", {
@@ -41921,11 +41925,13 @@ var library_renderers = (function (exports) {
 	   * Render
 	   *******************************************************/
 	  render() {
-	    let projects = this.state.projects.map(project => /*#__PURE__*/reactExports.createElement(WorkflowForMenu$1, {
+	    let projects = this.state.projects.map((project, index) => /*#__PURE__*/reactExports.createElement(WorkflowForMenu$1, {
+	      key: `project-${index}`,
 	      workflow_data: project,
 	      renderer: this.props.renderer
 	    }));
-	    let favourites = this.state.favourites.map(project => /*#__PURE__*/reactExports.createElement(WorkflowForMenu$1, {
+	    let favourites = this.state.favourites.map((project, index) => /*#__PURE__*/reactExports.createElement(WorkflowForMenu$1, {
+	      key: `favourite-${index}`,
 	      workflow_data: project,
 	      renderer: this.props.renderer
 	    }));

--- a/course_flow/static/course_flow/js/react/dist/scripts-library.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-library.min.js
@@ -38261,6 +38261,119 @@ var library_renderers = (function (exports) {
 	  }
 	};
 
+	//Text that can be passed a default value. HTML is dangerously set.
+	class TitleText extends reactExports.Component {
+	  render() {
+	    var text = this.props.text;
+	    if ((this.props.text == null || this.props.text == '') && this.props.defaultText != null) {
+	      text = this.props.defaultText;
+	    }
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "title-text",
+	      title: text,
+	      dangerouslySetInnerHTML: {
+	        __html: text
+	      }
+	    });
+	  }
+	}
+
+	//Title text for a workflow
+	let WorkflowTitle$1 = class WorkflowTitle extends reactExports.Component {
+	  render() {
+	    let data = this.props.data;
+	    let text = data.title;
+	    if (data.code) text = data.code + ' - ' + text;
+	    if (text == null || text == '') {
+	      text = gettext('Untitled');
+	    }
+	    if (data.url == 'noaccess' || data.url == 'nouser') {
+	      text += gettext(' (no access)');
+	    }
+	    if (data.deleted) {
+	      text += ' (deleted)';
+	    }
+	    let href = data.url;
+	    if (!data.url) href = config.update_path[data.type].replace('0', data.id);
+	    if (this.props.no_hyperlink || data.url == 'noaccess' || data.url == 'nouser') {
+	      return /*#__PURE__*/reactExports.createElement("div", {
+	        className: this.props.class_name,
+	        "data-test-id": this.props.test_id,
+	        title: text,
+	        dangerouslySetInnerHTML: {
+	          __html: text
+	        }
+	      });
+	    } else {
+	      return /*#__PURE__*/reactExports.createElement("a", {
+	        onClick: evt => evt.stopPropagation(),
+	        href: href,
+	        className: this.props.class_name,
+	        "data-test-id": this.props.test_id,
+	        title: text,
+	        dangerouslySetInnerHTML: {
+	          __html: text
+	        }
+	      });
+	    }
+	  }
+	};
+
+	//Title text for a node
+	class NodeTitle extends reactExports.Component {
+	  render() {
+	    let data = this.props.data;
+	    let text;
+	    if (data.represents_workflow && data.linked_workflow_data) {
+	      text = data.linked_workflow_data.title;
+	      if (data.linked_workflow_data.code) text = data.linked_workflow_data.code + ' - ' + text;
+	    } else text = data.title;
+	    if (text == null || text == '') {
+	      text = gettext('Untitled');
+	    }
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "node-title",
+	      title: text,
+	      dangerouslySetInnerHTML: {
+	        __html: text
+	      }
+	    });
+	  }
+	}
+
+	//Title text for an assignment
+	class AssignmentTitle extends reactExports.Component {
+	  render() {
+	    let data = this.props.data;
+	    let text;
+	    if (data.task.represents_workflow && data.task.linked_workflow_data) {
+	      text = data.task.linked_workflow_data.title;
+	      if (data.task.linked_workflow_data.code) text = data.task.linked_workflow_data.code + ' - ' + text;
+	    } else text = data.task.title;
+	    if (text == null || text == '') {
+	      text = gettext('Untitled');
+	    }
+	    if (this.props.user_role == role_keys.teacher) {
+	      return /*#__PURE__*/reactExports.createElement("a", {
+	        href: config.update_path.liveassignment.replace('0', data.id),
+	        className: "workflow-title hover-shade",
+	        title: text,
+	        dangerouslySetInnerHTML: {
+	          __html: text
+	        }
+	      });
+	    } else {
+	      return /*#__PURE__*/reactExports.createElement("span", {
+	        className: "workflow-title",
+	        title: text,
+	        dangerouslySetInnerHTML: {
+	          __html: text
+	        }
+	      });
+	    }
+	  }
+	}
+
 	//Basic component to represent a node in the outcomes table
 	class NodeOutcomeViewUnconnected extends Component {
 	  constructor(props) {
@@ -38359,117 +38472,6 @@ var library_renderers = (function (exports) {
 	      class_name: "workflow-title",
 	      data: data
 	    }), this.getTypeIndicator()));
-	  }
-	}
-
-	//Text that can be passed a default value. HTML is dangerously set.
-	class TitleText extends reactExports.Component {
-	  render() {
-	    var text = this.props.text;
-	    if ((this.props.text == null || this.props.text == '') && this.props.defaultText != null) {
-	      text = this.props.defaultText;
-	    }
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "title-text",
-	      title: text,
-	      dangerouslySetInnerHTML: {
-	        __html: text
-	      }
-	    });
-	  }
-	}
-
-	//Title text for a workflow
-	let WorkflowTitle$1 = class WorkflowTitle extends reactExports.Component {
-	  render() {
-	    let data = this.props.data;
-	    let text = data.title;
-	    if (data.code) text = data.code + ' - ' + text;
-	    if (text == null || text == '') {
-	      text = gettext('Untitled');
-	    }
-	    if (data.url == 'noaccess' || data.url == 'nouser') {
-	      text += gettext(' (no access)');
-	    }
-	    if (data.deleted) {
-	      text += ' (deleted)';
-	    }
-	    let href = data.url;
-	    if (!data.url) href = config.update_path[data.type].replace('0', data.id);
-	    if (this.props.no_hyperlink || data.url == 'noaccess' || data.url == 'nouser') {
-	      return /*#__PURE__*/reactExports.createElement("div", {
-	        className: this.props.class_name,
-	        title: text,
-	        dangerouslySetInnerHTML: {
-	          __html: text
-	        }
-	      });
-	    } else {
-	      return /*#__PURE__*/reactExports.createElement("a", {
-	        onClick: evt => evt.stopPropagation(),
-	        href: href,
-	        className: this.props.class_name,
-	        title: text,
-	        dangerouslySetInnerHTML: {
-	          __html: text
-	        }
-	      });
-	    }
-	  }
-	};
-
-	//Title text for a node
-	class NodeTitle extends reactExports.Component {
-	  render() {
-	    let data = this.props.data;
-	    let text;
-	    if (data.represents_workflow && data.linked_workflow_data) {
-	      text = data.linked_workflow_data.title;
-	      if (data.linked_workflow_data.code) text = data.linked_workflow_data.code + ' - ' + text;
-	    } else text = data.title;
-	    if (text == null || text == '') {
-	      text = gettext('Untitled');
-	    }
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "node-title",
-	      title: text,
-	      dangerouslySetInnerHTML: {
-	        __html: text
-	      }
-	    });
-	  }
-	}
-
-	//Title text for an assignment
-	class AssignmentTitle extends reactExports.Component {
-	  render() {
-	    let data = this.props.data;
-	    let text;
-	    if (data.task.represents_workflow && data.task.linked_workflow_data) {
-	      text = data.task.linked_workflow_data.title;
-	      if (data.task.linked_workflow_data.code) text = data.task.linked_workflow_data.code + ' - ' + text;
-	    } else text = data.task.title;
-	    if (text == null || text == '') {
-	      text = gettext('Untitled');
-	    }
-	    if (this.props.user_role == role_keys.teacher) {
-	      return /*#__PURE__*/reactExports.createElement("a", {
-	        href: config.update_path.liveassignment.replace('0', data.id),
-	        className: "workflow-title hover-shade",
-	        title: text,
-	        dangerouslySetInnerHTML: {
-	          __html: text
-	        }
-	      });
-	    } else {
-	      return /*#__PURE__*/reactExports.createElement("span", {
-	        className: "workflow-title",
-	        title: text,
-	        dangerouslySetInnerHTML: {
-	          __html: text
-	        }
-	      });
-	    }
 	  }
 	}
 
@@ -39932,6 +39934,166 @@ var library_renderers = (function (exports) {
 	  }
 	}
 
+	class LiveProjectCompletionTable extends LiveProjectSection {
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    this.state.liveproject;
+	    let head = this.state.data.assignments.map(assignment => /*#__PURE__*/reactExports.createElement("th", {
+	      className: "table-cell nodewrapper"
+	    }, /*#__PURE__*/reactExports.createElement(AssignmentViewSmall, {
+	      renderer: this.props.renderer,
+	      data: assignment
+	    })));
+	    let assignment_ids = this.state.data.assignments.map(assignment => assignment.id);
+	    let body = this.state.data.table_rows.map((row, row_index) => /*#__PURE__*/reactExports.createElement("tr", {
+	      className: "outcome-row"
+	    }, /*#__PURE__*/reactExports.createElement("td", {
+	      className: "user-head outcome-head"
+	    }, getUserDisplay(row.user)), assignment_ids.map(id => {
+	      let assignment = row.assignments.find(row_element => row_element.assignment == id);
+	      if (!assignment) return /*#__PURE__*/reactExports.createElement("td", {
+	        className: "table-cell"
+	      });
+	      return /*#__PURE__*/reactExports.createElement("td", {
+	        className: "table-cell"
+	      }, /*#__PURE__*/reactExports.createElement("input", {
+	        onChange: this.toggleCompletion.bind(this, assignment.id, row_index),
+	        type: "checkbox",
+	        checked: assignment.completed
+	      }));
+	    }), /*#__PURE__*/reactExports.createElement("td", {
+	      className: "table-cell total-cell grand-total-cell"
+	    }, row.assignments.reduce((total, assignment) => total + assignment.completed, 0) + '/' + row.assignments.length)));
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Table'), ":"), /*#__PURE__*/reactExports.createElement("table", {
+	      className: "user-table outcome-table node-rows"
+	    }, /*#__PURE__*/reactExports.createElement("tr", {
+	      className: "outcome-row node-row"
+	    }, /*#__PURE__*/reactExports.createElement("th", {
+	      className: "user-head outcome-head empty"
+	    }), head, /*#__PURE__*/reactExports.createElement("th", {
+	      className: "table-cell nodewrapper total-cell grand-total-cell"
+	    }, /*#__PURE__*/reactExports.createElement("div", {
+	      className: "total-header"
+	    }, gettext('Total'), ":"))), body));
+	  }
+	  toggleCompletion(id, row_index, evt) {
+	    setAssignmentCompletion(id, evt.target.checked);
+	    let new_data = {
+	      ...this.state.data
+	    };
+	    new_data.table_rows = new_data.table_rows.slice();
+	    new_data.table_rows[row_index] = {
+	      ...new_data.table_rows[row_index]
+	    };
+	    new_data.table_rows[row_index].assignments = new_data.table_rows[row_index].assignments.slice();
+	    let index = new_data.table_rows[row_index].assignments.findIndex(assignment => assignment.id == id);
+	    new_data.table_rows[row_index].assignments[index] = {
+	      ...new_data.table_rows[row_index].assignments[index],
+	      completed: evt.target.checked
+	    };
+	    this.setState({
+	      data: new_data
+	    });
+	  }
+	}
+
+	class LiveProjectSettings extends LiveProjectSection {
+	  constructor(props) {
+	    super(props);
+	    this.state = {
+	      has_changed: false,
+	      liveproject: null
+	    };
+	    this.changed_values = {};
+	  }
+
+	  /*******************************************************
+	   * FUNCTIONS
+	   *******************************************************/
+
+	  changeField(type, new_value) {
+	    let new_state = {
+	      ...this.state.data.liveproject
+	    };
+	    new_state[type] = new_value;
+	    this.changed_values[type] = new_value;
+	    this.setState({
+	      has_changed: true,
+	      data: {
+	        ...this.state.data,
+	        liveproject: new_state
+	      }
+	    });
+	  }
+	  saveChanges() {
+	    updateLiveProjectValue(this.state.data.liveproject.id, 'liveproject', this.changed_values);
+	    this.props.updateLiveProject({
+	      liveproject: {
+	        ...this.state.data.liveproject,
+	        ...this.changed_values
+	      }
+	    });
+	    this.changed_values = {};
+	    this.setState({
+	      has_changed: false
+	    });
+	  }
+	  /*******************************************************
+	   * RENDER
+	   *******************************************************/
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    console.log(this.state);
+	    let data = this.state.data.liveproject;
+	    let changeField = this.changeField.bind(this);
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h4", null, gettext('Classroom configuration'), ":"), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
+	      id: "default-single-completion",
+	      name: "default-single-completion",
+	      type: "checkbox",
+	      checked: data.default_single_completion,
+	      onChange: evt => changeField('default_single_completion', evt.target.checked)
+	    }), /*#__PURE__*/reactExports.createElement("label", {
+	      htmlFor: "default-signle-completion",
+	      title: gettext('Whether to mark the assignment as complete if any user has completed it.')
+	    }, gettext('By default, mark assignments as complete when a single user has completed them'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
+	      id: "default-assign-to-all",
+	      name: "default-assign-to-all",
+	      type: "checkbox",
+	      checked: data.default_assign_to_all,
+	      onChange: evt => changeField('default_assign_to_all', evt.target.checked)
+	    }), /*#__PURE__*/reactExports.createElement("label", {
+	      htmlFor: "default-assign-to-all",
+	      title: gettext('Whether creating an assignment automatically adds all students to it.')
+	    }, gettext('Assign new assignments to all students by default'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
+	      id: "default-self-reporting",
+	      name: "default-self-reporting",
+	      type: "checkbox",
+	      checked: data.default_self_reporting,
+	      onChange: evt => changeField('default_self_reporting', evt.target.checked)
+	    }), /*#__PURE__*/reactExports.createElement("label", {
+	      htmlFor: "default-self-reporting",
+	      title: gettext('Whether students can mark their own assignments as complete.')
+	    }, gettext('Let students self-report their assignment completion by default'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
+	      id: "default-all-workflows-visible",
+	      name: "default-all-workflows-visible",
+	      type: "checkbox",
+	      checked: data.default_all_workflows_visible,
+	      onChange: evt => changeField('default_all_workflows_visible', evt.target.checked)
+	    }), /*#__PURE__*/reactExports.createElement("label", {
+	      htmlFor: "default-all-workflows-visible",
+	      title: gettext('Whether all workflows in the project will be visible to students by default.')
+	    }, gettext('All Workflows Visible To Students'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("button", {
+	      className: "primary-button",
+	      disabled: !this.state.has_changed,
+	      onClick: this.saveChanges.bind(this)
+	    }, gettext('Save classroom changes'))));
+	  }
+	}
+
 	class AssignmentWorkflowNodesDisplay extends reactExports.Component {
 	  constructor(props) {
 	    super(props);
@@ -40086,169 +40248,6 @@ var library_renderers = (function (exports) {
 	    }, workflow_options), workflow_nodes);
 	  }
 	}
-	var LiveProjectAssignments$1 = LiveProjectAssignments;
-
-	class LiveProjectCompletionTable extends LiveProjectSection {
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    this.state.liveproject;
-	    let head = this.state.data.assignments.map(assignment => /*#__PURE__*/reactExports.createElement("th", {
-	      className: "table-cell nodewrapper"
-	    }, /*#__PURE__*/reactExports.createElement(AssignmentViewSmall, {
-	      renderer: this.props.renderer,
-	      data: assignment
-	    })));
-	    let assignment_ids = this.state.data.assignments.map(assignment => assignment.id);
-	    let body = this.state.data.table_rows.map((row, row_index) => /*#__PURE__*/reactExports.createElement("tr", {
-	      className: "outcome-row"
-	    }, /*#__PURE__*/reactExports.createElement("td", {
-	      className: "user-head outcome-head"
-	    }, getUserDisplay(row.user)), assignment_ids.map(id => {
-	      let assignment = row.assignments.find(row_element => row_element.assignment == id);
-	      if (!assignment) return /*#__PURE__*/reactExports.createElement("td", {
-	        className: "table-cell"
-	      });
-	      return /*#__PURE__*/reactExports.createElement("td", {
-	        className: "table-cell"
-	      }, /*#__PURE__*/reactExports.createElement("input", {
-	        onChange: this.toggleCompletion.bind(this, assignment.id, row_index),
-	        type: "checkbox",
-	        checked: assignment.completed
-	      }));
-	    }), /*#__PURE__*/reactExports.createElement("td", {
-	      className: "table-cell total-cell grand-total-cell"
-	    }, row.assignments.reduce((total, assignment) => total + assignment.completed, 0) + '/' + row.assignments.length)));
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Table'), ":"), /*#__PURE__*/reactExports.createElement("table", {
-	      className: "user-table outcome-table node-rows"
-	    }, /*#__PURE__*/reactExports.createElement("tr", {
-	      className: "outcome-row node-row"
-	    }, /*#__PURE__*/reactExports.createElement("th", {
-	      className: "user-head outcome-head empty"
-	    }), head, /*#__PURE__*/reactExports.createElement("th", {
-	      className: "table-cell nodewrapper total-cell grand-total-cell"
-	    }, /*#__PURE__*/reactExports.createElement("div", {
-	      className: "total-header"
-	    }, gettext('Total'), ":"))), body));
-	  }
-	  toggleCompletion(id, row_index, evt) {
-	    setAssignmentCompletion(id, evt.target.checked);
-	    let new_data = {
-	      ...this.state.data
-	    };
-	    new_data.table_rows = new_data.table_rows.slice();
-	    new_data.table_rows[row_index] = {
-	      ...new_data.table_rows[row_index]
-	    };
-	    new_data.table_rows[row_index].assignments = new_data.table_rows[row_index].assignments.slice();
-	    let index = new_data.table_rows[row_index].assignments.findIndex(assignment => assignment.id == id);
-	    new_data.table_rows[row_index].assignments[index] = {
-	      ...new_data.table_rows[row_index].assignments[index],
-	      completed: evt.target.checked
-	    };
-	    this.setState({
-	      data: new_data
-	    });
-	  }
-	}
-	var LiveProjectCompletionTable$1 = LiveProjectCompletionTable;
-
-	class LiveProjectSettings extends LiveProjectSection {
-	  constructor(props) {
-	    super(props);
-	    this.state = {
-	      has_changed: false,
-	      liveproject: null
-	    };
-	    this.changed_values = {};
-	  }
-
-	  /*******************************************************
-	   * FUNCTIONS
-	   *******************************************************/
-
-	  changeField(type, new_value) {
-	    let new_state = {
-	      ...this.state.data.liveproject
-	    };
-	    new_state[type] = new_value;
-	    this.changed_values[type] = new_value;
-	    this.setState({
-	      has_changed: true,
-	      data: {
-	        ...this.state.data,
-	        liveproject: new_state
-	      }
-	    });
-	  }
-	  saveChanges() {
-	    updateLiveProjectValue(this.state.data.liveproject.id, 'liveproject', this.changed_values);
-	    this.props.updateLiveProject({
-	      liveproject: {
-	        ...this.state.data.liveproject,
-	        ...this.changed_values
-	      }
-	    });
-	    this.changed_values = {};
-	    this.setState({
-	      has_changed: false
-	    });
-	  }
-	  /*******************************************************
-	   * RENDER
-	   *******************************************************/
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    console.log(this.state);
-	    let data = this.state.data.liveproject;
-	    let changeField = this.changeField.bind(this);
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h4", null, gettext('Classroom configuration'), ":"), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
-	      id: "default-single-completion",
-	      name: "default-single-completion",
-	      type: "checkbox",
-	      checked: data.default_single_completion,
-	      onChange: evt => changeField('default_single_completion', evt.target.checked)
-	    }), /*#__PURE__*/reactExports.createElement("label", {
-	      htmlFor: "default-signle-completion",
-	      title: gettext('Whether to mark the assignment as complete if any user has completed it.')
-	    }, gettext('By default, mark assignments as complete when a single user has completed them'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
-	      id: "default-assign-to-all",
-	      name: "default-assign-to-all",
-	      type: "checkbox",
-	      checked: data.default_assign_to_all,
-	      onChange: evt => changeField('default_assign_to_all', evt.target.checked)
-	    }), /*#__PURE__*/reactExports.createElement("label", {
-	      htmlFor: "default-assign-to-all",
-	      title: gettext('Whether creating an assignment automatically adds all students to it.')
-	    }, gettext('Assign new assignments to all students by default'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
-	      id: "default-self-reporting",
-	      name: "default-self-reporting",
-	      type: "checkbox",
-	      checked: data.default_self_reporting,
-	      onChange: evt => changeField('default_self_reporting', evt.target.checked)
-	    }), /*#__PURE__*/reactExports.createElement("label", {
-	      htmlFor: "default-self-reporting",
-	      title: gettext('Whether students can mark their own assignments as complete.')
-	    }, gettext('Let students self-report their assignment completion by default'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("input", {
-	      id: "default-all-workflows-visible",
-	      name: "default-all-workflows-visible",
-	      type: "checkbox",
-	      checked: data.default_all_workflows_visible,
-	      onChange: evt => changeField('default_all_workflows_visible', evt.target.checked)
-	    }), /*#__PURE__*/reactExports.createElement("label", {
-	      htmlFor: "default-all-workflows-visible",
-	      title: gettext('Whether all workflows in the project will be visible to students by default.')
-	    }, gettext('All Workflows Visible To Students'))), /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement("button", {
-	      className: "primary-button",
-	      disabled: !this.state.has_changed,
-	      onClick: this.saveChanges.bind(this)
-	    }, gettext('Save classroom changes'))));
-	  }
-	}
-	var LiveProjectSettings$1 = LiveProjectSettings;
 
 	/*
 	The menu for editing a project.
@@ -40382,7 +40381,7 @@ var library_renderers = (function (exports) {
 	  }
 	  getLiveProjectSettings() {
 	    if (this.props.data.renderer.user_role === role_keys.teacher) {
-	      return /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement(LiveProjectSettings$1, {
+	      return /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement(LiveProjectSettings, {
 	        renderer: this.props.renderer,
 	        role: 'teacher',
 	        objectID: this.state.id,
@@ -42063,7 +42062,7 @@ var library_renderers = (function (exports) {
 	        }));
 	        break;
 	      case 'assignments':
-	        return_val.push( /*#__PURE__*/reactExports.createElement(LiveProjectAssignments$1, {
+	        return_val.push( /*#__PURE__*/reactExports.createElement(LiveProjectAssignments, {
 	          renderer: this.props.renderer,
 	          role: this.getRole(),
 	          objectID: this.state.data.id,
@@ -42071,7 +42070,7 @@ var library_renderers = (function (exports) {
 	        }));
 	        break;
 	      case 'completion_table':
-	        return_val.push( /*#__PURE__*/reactExports.createElement(LiveProjectCompletionTable$1, {
+	        return_val.push( /*#__PURE__*/reactExports.createElement(LiveProjectCompletionTable, {
 	          renderer: this.props.renderer,
 	          role: this.getRole(),
 	          objectID: this.props.data.id,

--- a/course_flow/static/course_flow/js/react/dist/scripts-live.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-live.min.js
@@ -34134,6 +34134,7 @@ var live_renderers = (function (exports) {
 	    if (this.props.no_hyperlink || data.url == 'noaccess' || data.url == 'nouser') {
 	      return /*#__PURE__*/reactExports.createElement("div", {
 	        className: this.props.class_name,
+	        "data-test-id": this.props.test_id,
 	        title: text,
 	        dangerouslySetInnerHTML: {
 	          __html: text
@@ -34144,6 +34145,7 @@ var live_renderers = (function (exports) {
 	        onClick: evt => evt.stopPropagation(),
 	        href: href,
 	        className: this.props.class_name,
+	        "data-test-id": this.props.test_id,
 	        title: text,
 	        dangerouslySetInnerHTML: {
 	          __html: text
@@ -39046,209 +39048,6 @@ var live_renderers = (function (exports) {
 	  }
 	}
 
-	/**
-	 *
-	 */
-	class LiveProjectWorkflows extends LiveProjectSection {
-	  /*******************************************************
-	   * FUNCTIONS
-	   *******************************************************/
-	  switchVisibility(pk, visibility) {
-	    let workflows_added = this.state.data.workflows_added.slice();
-	    let workflows_not_added = this.state.data.workflows_not_added.slice();
-	    if (visibility == 'visible') {
-	      for (let i = 0; i < workflows_not_added.length; i++) {
-	        if (workflows_not_added[i].id == pk) {
-	          let removed = workflows_not_added.splice(i, 1);
-	          setWorkflowVisibility(this.props.objectID, pk, true);
-	          workflows_added.push(removed[0]);
-	        }
-	      }
-	    } else {
-	      for (let i = 0; i < workflows_added.length; i++) {
-	        if (workflows_added[i].id == pk) {
-	          let removed = workflows_added.splice(i, 1);
-	          setWorkflowVisibility(this.props.objectID, pk, false);
-	          workflows_not_added.push(removed[0]);
-	        }
-	      }
-	    }
-	    this.setState({
-	      data: {
-	        ...this.state.data,
-	        workflows_added: workflows_added,
-	        workflows_not_added: workflows_not_added
-	      }
-	    });
-	  }
-
-	  /*******************************************************
-	   * RENDER
-	   *******************************************************/
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    let workflows_added = this.state.data.workflows_added.map(workflow => /*#__PURE__*/reactExports.createElement(WorkflowVisibility, {
-	      workflow_data: workflow,
-	      visibility: "visible",
-	      visibilityFunction: this.switchVisibility.bind(this)
-	    }));
-	    let workflows_not_added = this.state.data.workflows_not_added.map(workflow => /*#__PURE__*/reactExports.createElement(WorkflowVisibility, {
-	      workflow_data: workflow,
-	      visibility: "not_visible",
-	      visibilityFunction: this.switchVisibility.bind(this)
-	    }));
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Visible Workflows')), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "menu-grid"
-	    }, workflows_added), /*#__PURE__*/reactExports.createElement("h3", null, gettext('Other Workflows')), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "menu-grid"
-	    }, workflows_not_added));
-	  }
-	}
-
-	/**
-	 *
-	 */
-	class LiveProjectMenu extends reactExports.Component {
-	  constructor(props) {
-	    super(props);
-	    this.state = {
-	      ...props.project,
-	      liveproject: this.props.liveproject,
-	      view_type: 'overview'
-	    };
-	  }
-
-	  /*******************************************************
-	   * FUNCTIONS
-	   *******************************************************/
-	  getViewButtons() {
-	    return [{
-	      type: 'overview',
-	      name: gettext('Classroom Overview')
-	    }, {
-	      type: 'students',
-	      name: gettext('Students')
-	    }, {
-	      type: 'assignments',
-	      name: gettext('Assignments')
-	    }, {
-	      type: 'workflows',
-	      name: gettext('Workflow Visibility')
-	    }, {
-	      type: 'completion_table',
-	      name: gettext('Completion Table')
-	    }, {
-	      type: 'settings',
-	      name: gettext('Classroom Settings')
-	    }];
-	  }
-	  getRole() {
-	    return 'teacher';
-	  }
-	  openEdit() {
-	    return null;
-	  }
-	  changeView(view_type) {
-	    this.setState({
-	      view_type: view_type
-	    });
-	  }
-	  getHeader() {
-	    return null;
-	  }
-	  getContent() {
-	    switch (this.state.view_type) {
-	      case 'overview':
-	        return /*#__PURE__*/reactExports.createElement(LiveProjectOverview, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'students':
-	        return /*#__PURE__*/reactExports.createElement(LiveProjectStudents, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          liveproject: this.state.liveproject,
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'assignments':
-	        return /*#__PURE__*/reactExports.createElement(LiveProjectAssignments$1, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'workflows':
-	        return /*#__PURE__*/reactExports.createElement(LiveProjectWorkflows, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'completion_table':
-	        return /*#__PURE__*/reactExports.createElement(LiveProjectCompletionTable$1, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'settings':
-	        return /*#__PURE__*/reactExports.createElement(LiveProjectSettings$1, {
-	          updateLiveProject: this.updateFunction.bind(this),
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          liveproject: this.state.liveproject,
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	    }
-	  }
-	  updateFunction(new_state) {
-	    this.setState(new_state);
-	  }
-
-	  /*******************************************************
-	   * RENDER
-	   *******************************************************/
-	  render() {
-	    let data = this.props.project;
-	    let overflow_links = [];
-	    if (this.props.renderer.user_permission > 0) {
-	      overflow_links.push( /*#__PURE__*/reactExports.createElement("a", {
-	        id: "project",
-	        className: "hover-shade",
-	        href: config.update_path.project.replace('0', data.id)
-	      }, gettext('Edit Project')));
-	    }
-	    let view_buttons = this.getViewButtons().map(item => {
-	      let view_class = 'hover-shade';
-	      if (item.type == this.state.view_type) view_class += ' active';
-	      return /*#__PURE__*/reactExports.createElement("a", {
-	        id: 'button_' + item.type,
-	        className: view_class,
-	        onClick: this.changeView.bind(this, item.type)
-	      }, item.name);
-	    });
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "project-menu"
-	    }, /*#__PURE__*/reactExports.createElement("div", {
-	      className: "project-header"
-	    }, /*#__PURE__*/reactExports.createElement(WorkflowForMenu, {
-	      no_hyperlink: true,
-	      workflow_data: this.state.liveproject,
-	      selectAction: this.openEdit.bind(this)
-	    }), this.getHeader()), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-view-select hide-print"
-	    }, view_buttons), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-container"
-	    }, this.getContent()), reactDomExports.createPortal(overflow_links, $('#overflow-links')[0]));
-	  }
-	}
-
 	class AssignmentView extends reactExports.Component {
 	  constructor(props) {
 	    super(props);
@@ -39784,279 +39583,6 @@ var live_renderers = (function (exports) {
 	  }
 	}
 
-	class StudentLiveProjectOverview extends LiveProjectSection {
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    let workflows = this.state.data.workflows.map(workflow => /*#__PURE__*/reactExports.createElement(SimpleWorkflow$1, {
-	      workflow_data: workflow
-	    }));
-	    if (workflows.length == 0) workflows = gettext('No workflows have been made visible to students.');
-	    let assignments = this.state.data.assignments.filter(assignment => assignment.user_assignment.completed == false).map(assignment => /*#__PURE__*/reactExports.createElement("tr", null, /*#__PURE__*/reactExports.createElement("td", null, /*#__PURE__*/reactExports.createElement(AssignmentTitle, {
-	      data: assignment,
-	      user_role: this.props.renderer.user_role
-	    })), /*#__PURE__*/reactExports.createElement("td", null, /*#__PURE__*/reactExports.createElement("input", {
-	      type: "checkbox",
-	      disabled: !assignment.self_reporting,
-	      onChange: this.toggleAssignment.bind(this, assignment.user_assignment.id)
-	    })), /*#__PURE__*/reactExports.createElement("td", null, /*#__PURE__*/reactExports.createElement(DatePicker, {
-	      default_value: assignment.end_date,
-	      disabled: true
-	    }))));
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Your Incomplete Assignments'), ":"), /*#__PURE__*/reactExports.createElement("table", {
-	      className: "overview-table"
-	    }, /*#__PURE__*/reactExports.createElement("tr", null, /*#__PURE__*/reactExports.createElement("th", null, gettext('Assignment')), /*#__PURE__*/reactExports.createElement("th", null, gettext('Completion')), /*#__PURE__*/reactExports.createElement("th", null, gettext('End Date'))), assignments), /*#__PURE__*/reactExports.createElement("h3", null, gettext('Visible Workflows'), ":"), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "menu-grid"
-	    }, workflows));
-	  }
-	  toggleAssignment(id, evt) {
-	    setAssignmentCompletion(id, evt.target.checked);
-	  }
-	}
-
-	/**
-	 *
-	 */
-	class StudentLiveProjectWorkflows extends LiveProjectSection {
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    let workflows_added = this.state.data.workflows_added.map(workflow => /*#__PURE__*/reactExports.createElement(WorkflowForMenu, {
-	      workflow_data: workflow
-	    }));
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Workflows')), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "menu-grid"
-	    }, workflows_added));
-	  }
-	}
-
-	/**
-	 *
-	 */
-	class StudentLiveProjectAssignments extends LiveProjectSection {
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    let assignments_past = this.state.data.assignments_past.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
-	      renderer: this.props.renderer,
-	      data: assignment
-	    }));
-	    let assignments_upcoming = this.state.data.assignments_upcoming.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
-	      renderer: this.props.renderer,
-	      data: assignment
-	    }));
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Your Tasks'), ":"), /*#__PURE__*/reactExports.createElement("h4", null, gettext('Upcoming'), ":"), /*#__PURE__*/reactExports.createElement("div", null, assignments_upcoming), /*#__PURE__*/reactExports.createElement("h4", null, gettext('Past'), ":"), /*#__PURE__*/reactExports.createElement("div", null, assignments_past));
-	  }
-	}
-
-	/**
-	 *
-	 */
-	class StudentLiveProjectMenu extends LiveProjectMenu {
-	  getViewButtons() {
-	    return [{
-	      type: 'overview',
-	      name: gettext('Classroom Overview')
-	    }, {
-	      type: 'assignments',
-	      name: gettext('My Assignments')
-	    }, {
-	      type: 'workflows',
-	      name: gettext('My Workflows')
-	    }];
-	  }
-	  getRole() {
-	    return 'student';
-	  }
-	  getContent() {
-	    switch (this.state.view_type) {
-	      case 'overview':
-	        return /*#__PURE__*/reactExports.createElement(StudentLiveProjectOverview, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'assignments':
-	        return /*#__PURE__*/reactExports.createElement(StudentLiveProjectAssignments, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	      case 'workflows':
-	        return /*#__PURE__*/reactExports.createElement(StudentLiveProjectWorkflows, {
-	          renderer: this.props.renderer,
-	          role: this.getRole(),
-	          objectID: this.props.project.id,
-	          view_type: this.state.view_type
-	        });
-	    }
-	  }
-	  updateFunction(new_state) {
-	    this.setState(new_state);
-	  }
-	}
-
-	class AssignmentWorkflowNodesDisplay extends reactExports.Component {
-	  constructor(props) {
-	    super(props);
-	    this.state = {};
-	  }
-
-	  /*******************************************************
-	   * LIFECYCLE
-	   *******************************************************/
-	  componentDidMount() {
-	    this.getData();
-	  }
-	  componentDidUpdate(prevProps) {
-	    if (prevProps.objectID != this.props.objectID) {
-	      this.setState({
-	        data: null
-	      }, this.getData.bind(this));
-	    }
-	  }
-
-	  /*******************************************************
-	   * RENDER
-	   *******************************************************/
-	  getData() {
-	    let component = this;
-	    getWorkflowNodes(this.props.objectID, data => {
-	      component.setState({
-	        data: data.data_package
-	      });
-	    });
-	  }
-	  defaultRender() {
-	    // @todo undefined scope error
-	    return /*#__PURE__*/reactExports.createElement(renderers.WorkflowLoader, null);
-	  }
-
-	  /*******************************************************
-	   * RENDER
-	   *******************************************************/
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    let weeks = this.state.data.weeks.map((week, i) => {
-	      let nodes = week.nodes.map(node => /*#__PURE__*/reactExports.createElement(AssignmentNode, {
-	        renderer: this.props.renderer,
-	        data: node
-	      }));
-	      let default_text;
-	      default_text = week.week_type_display + ' ' + (i + 1);
-	      return /*#__PURE__*/reactExports.createElement("div", {
-	        className: "week"
-	      }, /*#__PURE__*/reactExports.createElement(TitleText, {
-	        text: week.title,
-	        defaultText: default_text
-	      }), /*#__PURE__*/reactExports.createElement("div", {
-	        className: "node-block-grid"
-	      }, nodes));
-	    });
-	    return /*#__PURE__*/reactExports.createElement("div", null, weeks);
-	  }
-	}
-	class AssignmentNode extends reactExports.Component {
-	  render() {
-	    let data = this.props.data;
-	    let lefticon;
-	    let righticon;
-	    if (data.context_classification > 0) lefticon = /*#__PURE__*/reactExports.createElement("img", {
-	      title: renderer.context_choices.find(obj => obj.type == data.context_classification).name,
-	      src: config.icon_path + context_keys[data.context_classification] + '.svg'
-	    });
-	    if (data.task_classification > 0) righticon = /*#__PURE__*/reactExports.createElement("img", {
-	      title: renderer.task_choices.find(obj => obj.type == data.task_classification).name,
-	      src: config.icon_path + task_keys[data.task_classification] + '.svg'
-	    });
-	    let style = {
-	      backgroundColor: getColumnColour(this.props.data)
-	    };
-	    let mouseover_actions = [this.addCreateAssignment(data)];
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      style: style,
-	      className: "node"
-	    }, /*#__PURE__*/reactExports.createElement("div", {
-	      className: "mouseover-actions"
-	    }, mouseover_actions), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "node-top-row"
-	    }, /*#__PURE__*/reactExports.createElement("div", {
-	      className: "node-icon"
-	    }, lefticon), /*#__PURE__*/reactExports.createElement(NodeTitle, {
-	      data: this.props.data
-	    }), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "node-icon"
-	    }, righticon)), /*#__PURE__*/reactExports.createElement("div", {
-	      className: "node-drop-row"
-	    }));
-	  }
-	  addCreateAssignment(data) {
-	    return /*#__PURE__*/reactExports.createElement(ActionButton, {
-	      button_icon: "assignment.svg",
-	      button_class: "duplicate-self-button",
-	      titletext: gettext('Create Assignment'),
-	      handleClick: this.createAssignment.bind(this, data)
-	    });
-	  }
-	  createAssignment(data) {
-	    let props = this.props;
-	    props.renderer.tiny_loader.startLoad();
-	    createAssignment(data.id, props.renderer.project_data.id, response_data => {
-	      props.renderer.tiny_loader.endLoad();
-	      window.location = config.update_path.liveassignment.replace('0', response_data.assignmentPk);
-	    });
-	  }
-	}
-	class LiveProjectAssignments extends LiveProjectSection {
-	  changeView(workflow_id) {
-	    this.setState({
-	      selected_id: workflow_id
-	    });
-	  }
-
-	  /*******************************************************
-	   * RENDER
-	   *******************************************************/
-	  render() {
-	    if (!this.state.data) return this.defaultRender();
-	    let assignments = this.state.data.assignments.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
-	      renderer: this.props.renderer,
-	      data: assignment
-	    }));
-	    let workflow_options = this.state.data.workflows.map(workflow => {
-	      let view_class = 'hover-shade';
-	      if (workflow.id == this.state.selected_id) view_class += ' active';
-	      return /*#__PURE__*/reactExports.createElement("div", {
-	        id: 'button_' + workflow.id,
-	        className: view_class,
-	        onClick: this.changeView.bind(this, workflow.id)
-	      }, /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
-	        no_hyperlink: true,
-	        data: workflow
-	      }));
-	    });
-	    let workflow_nodes;
-	    if (this.state.selected_id) {
-	      workflow_nodes = /*#__PURE__*/reactExports.createElement(AssignmentWorkflowNodesDisplay, {
-	        renderer: this.props.renderer,
-	        objectID: this.state.selected_id
-	      });
-	    }
-	    return /*#__PURE__*/reactExports.createElement("div", {
-	      className: "workflow-details"
-	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Assigned Tasks')), /*#__PURE__*/reactExports.createElement("div", null, assignments), /*#__PURE__*/reactExports.createElement("h3", null, gettext('All Tasks')), /*#__PURE__*/reactExports.createElement("div", {
-	      id: "select-workflow",
-	      className: "workflow-view-select"
-	    }, workflow_options), workflow_nodes);
-	  }
-	}
-	var LiveProjectAssignments$1 = LiveProjectAssignments;
-
 	class LiveProjectCompletionTable extends LiveProjectSection {
 	  render() {
 	    if (!this.state.data) return this.defaultRender();
@@ -40218,6 +39744,482 @@ var live_renderers = (function (exports) {
 	  }
 	}
 	var LiveProjectSettings$1 = LiveProjectSettings;
+
+	class AssignmentWorkflowNodesDisplay extends reactExports.Component {
+	  constructor(props) {
+	    super(props);
+	    this.state = {};
+	  }
+
+	  /*******************************************************
+	   * LIFECYCLE
+	   *******************************************************/
+	  componentDidMount() {
+	    this.getData();
+	  }
+	  componentDidUpdate(prevProps) {
+	    if (prevProps.objectID != this.props.objectID) {
+	      this.setState({
+	        data: null
+	      }, this.getData.bind(this));
+	    }
+	  }
+
+	  /*******************************************************
+	   * RENDER
+	   *******************************************************/
+	  getData() {
+	    let component = this;
+	    getWorkflowNodes(this.props.objectID, data => {
+	      component.setState({
+	        data: data.data_package
+	      });
+	    });
+	  }
+	  defaultRender() {
+	    // @todo undefined scope error
+	    return /*#__PURE__*/reactExports.createElement(renderers.WorkflowLoader, null);
+	  }
+
+	  /*******************************************************
+	   * RENDER
+	   *******************************************************/
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    let weeks = this.state.data.weeks.map((week, i) => {
+	      let nodes = week.nodes.map(node => /*#__PURE__*/reactExports.createElement(AssignmentNode, {
+	        renderer: this.props.renderer,
+	        data: node
+	      }));
+	      let default_text;
+	      default_text = week.week_type_display + ' ' + (i + 1);
+	      return /*#__PURE__*/reactExports.createElement("div", {
+	        className: "week"
+	      }, /*#__PURE__*/reactExports.createElement(TitleText, {
+	        text: week.title,
+	        defaultText: default_text
+	      }), /*#__PURE__*/reactExports.createElement("div", {
+	        className: "node-block-grid"
+	      }, nodes));
+	    });
+	    return /*#__PURE__*/reactExports.createElement("div", null, weeks);
+	  }
+	}
+	class AssignmentNode extends reactExports.Component {
+	  render() {
+	    let data = this.props.data;
+	    let lefticon;
+	    let righticon;
+	    if (data.context_classification > 0) lefticon = /*#__PURE__*/reactExports.createElement("img", {
+	      title: renderer.context_choices.find(obj => obj.type == data.context_classification).name,
+	      src: config.icon_path + context_keys[data.context_classification] + '.svg'
+	    });
+	    if (data.task_classification > 0) righticon = /*#__PURE__*/reactExports.createElement("img", {
+	      title: renderer.task_choices.find(obj => obj.type == data.task_classification).name,
+	      src: config.icon_path + task_keys[data.task_classification] + '.svg'
+	    });
+	    let style = {
+	      backgroundColor: getColumnColour(this.props.data)
+	    };
+	    let mouseover_actions = [this.addCreateAssignment(data)];
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      style: style,
+	      className: "node"
+	    }, /*#__PURE__*/reactExports.createElement("div", {
+	      className: "mouseover-actions"
+	    }, mouseover_actions), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "node-top-row"
+	    }, /*#__PURE__*/reactExports.createElement("div", {
+	      className: "node-icon"
+	    }, lefticon), /*#__PURE__*/reactExports.createElement(NodeTitle, {
+	      data: this.props.data
+	    }), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "node-icon"
+	    }, righticon)), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "node-drop-row"
+	    }));
+	  }
+	  addCreateAssignment(data) {
+	    return /*#__PURE__*/reactExports.createElement(ActionButton, {
+	      button_icon: "assignment.svg",
+	      button_class: "duplicate-self-button",
+	      titletext: gettext('Create Assignment'),
+	      handleClick: this.createAssignment.bind(this, data)
+	    });
+	  }
+	  createAssignment(data) {
+	    let props = this.props;
+	    props.renderer.tiny_loader.startLoad();
+	    createAssignment(data.id, props.renderer.project_data.id, response_data => {
+	      props.renderer.tiny_loader.endLoad();
+	      window.location = config.update_path.liveassignment.replace('0', response_data.assignmentPk);
+	    });
+	  }
+	}
+	class LiveProjectAssignments extends LiveProjectSection {
+	  changeView(workflow_id) {
+	    this.setState({
+	      selected_id: workflow_id
+	    });
+	  }
+
+	  /*******************************************************
+	   * RENDER
+	   *******************************************************/
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    let assignments = this.state.data.assignments.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
+	      renderer: this.props.renderer,
+	      data: assignment
+	    }));
+	    let workflow_options = this.state.data.workflows.map(workflow => {
+	      let view_class = 'hover-shade';
+	      if (workflow.id == this.state.selected_id) view_class += ' active';
+	      return /*#__PURE__*/reactExports.createElement("div", {
+	        id: 'button_' + workflow.id,
+	        className: view_class,
+	        onClick: this.changeView.bind(this, workflow.id)
+	      }, /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
+	        no_hyperlink: true,
+	        data: workflow
+	      }));
+	    });
+	    let workflow_nodes;
+	    if (this.state.selected_id) {
+	      workflow_nodes = /*#__PURE__*/reactExports.createElement(AssignmentWorkflowNodesDisplay, {
+	        renderer: this.props.renderer,
+	        objectID: this.state.selected_id
+	      });
+	    }
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Assigned Tasks')), /*#__PURE__*/reactExports.createElement("div", null, assignments), /*#__PURE__*/reactExports.createElement("h3", null, gettext('All Tasks')), /*#__PURE__*/reactExports.createElement("div", {
+	      id: "select-workflow",
+	      className: "workflow-view-select"
+	    }, workflow_options), workflow_nodes);
+	  }
+	}
+	var LiveProjectAssignments$1 = LiveProjectAssignments;
+
+	/**
+	 *
+	 */
+	class LiveProjectWorkflows extends LiveProjectSection {
+	  /*******************************************************
+	   * FUNCTIONS
+	   *******************************************************/
+	  switchVisibility(pk, visibility) {
+	    let workflows_added = this.state.data.workflows_added.slice();
+	    let workflows_not_added = this.state.data.workflows_not_added.slice();
+	    if (visibility == 'visible') {
+	      for (let i = 0; i < workflows_not_added.length; i++) {
+	        if (workflows_not_added[i].id == pk) {
+	          let removed = workflows_not_added.splice(i, 1);
+	          setWorkflowVisibility(this.props.objectID, pk, true);
+	          workflows_added.push(removed[0]);
+	        }
+	      }
+	    } else {
+	      for (let i = 0; i < workflows_added.length; i++) {
+	        if (workflows_added[i].id == pk) {
+	          let removed = workflows_added.splice(i, 1);
+	          setWorkflowVisibility(this.props.objectID, pk, false);
+	          workflows_not_added.push(removed[0]);
+	        }
+	      }
+	    }
+	    this.setState({
+	      data: {
+	        ...this.state.data,
+	        workflows_added: workflows_added,
+	        workflows_not_added: workflows_not_added
+	      }
+	    });
+	  }
+
+	  /*******************************************************
+	   * RENDER
+	   *******************************************************/
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    let workflows_added = this.state.data.workflows_added.map(workflow => /*#__PURE__*/reactExports.createElement(WorkflowVisibility, {
+	      workflow_data: workflow,
+	      visibility: "visible",
+	      visibilityFunction: this.switchVisibility.bind(this)
+	    }));
+	    let workflows_not_added = this.state.data.workflows_not_added.map(workflow => /*#__PURE__*/reactExports.createElement(WorkflowVisibility, {
+	      workflow_data: workflow,
+	      visibility: "not_visible",
+	      visibilityFunction: this.switchVisibility.bind(this)
+	    }));
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Visible Workflows')), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "menu-grid"
+	    }, workflows_added), /*#__PURE__*/reactExports.createElement("h3", null, gettext('Other Workflows')), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "menu-grid"
+	    }, workflows_not_added));
+	  }
+	}
+
+	/**
+	 *
+	 */
+	class LiveProjectMenu extends reactExports.Component {
+	  constructor(props) {
+	    super(props);
+	    this.state = {
+	      ...props.project,
+	      liveproject: this.props.liveproject,
+	      view_type: 'overview'
+	    };
+	  }
+
+	  /*******************************************************
+	   * FUNCTIONS
+	   *******************************************************/
+	  getViewButtons() {
+	    return [{
+	      type: 'overview',
+	      name: gettext('Classroom Overview')
+	    }, {
+	      type: 'students',
+	      name: gettext('Students')
+	    }, {
+	      type: 'assignments',
+	      name: gettext('Assignments')
+	    }, {
+	      type: 'workflows',
+	      name: gettext('Workflow Visibility')
+	    }, {
+	      type: 'completion_table',
+	      name: gettext('Completion Table')
+	    }, {
+	      type: 'settings',
+	      name: gettext('Classroom Settings')
+	    }];
+	  }
+	  getRole() {
+	    return 'teacher';
+	  }
+	  openEdit() {
+	    return null;
+	  }
+	  changeView(view_type) {
+	    this.setState({
+	      view_type: view_type
+	    });
+	  }
+	  getHeader() {
+	    return null;
+	  }
+	  getContent() {
+	    switch (this.state.view_type) {
+	      case 'overview':
+	        return /*#__PURE__*/reactExports.createElement(LiveProjectOverview, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'students':
+	        return /*#__PURE__*/reactExports.createElement(LiveProjectStudents, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          liveproject: this.state.liveproject,
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'assignments':
+	        return /*#__PURE__*/reactExports.createElement(LiveProjectAssignments$1, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'workflows':
+	        return /*#__PURE__*/reactExports.createElement(LiveProjectWorkflows, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'completion_table':
+	        return /*#__PURE__*/reactExports.createElement(LiveProjectCompletionTable$1, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'settings':
+	        return /*#__PURE__*/reactExports.createElement(LiveProjectSettings$1, {
+	          updateLiveProject: this.updateFunction.bind(this),
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          liveproject: this.state.liveproject,
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	    }
+	  }
+	  updateFunction(new_state) {
+	    this.setState(new_state);
+	  }
+
+	  /*******************************************************
+	   * RENDER
+	   *******************************************************/
+	  render() {
+	    let data = this.props.project;
+	    let overflow_links = [];
+	    if (this.props.renderer.user_permission > 0) {
+	      overflow_links.push( /*#__PURE__*/reactExports.createElement("a", {
+	        id: "project",
+	        className: "hover-shade",
+	        href: config.update_path.project.replace('0', data.id)
+	      }, gettext('Edit Project')));
+	    }
+	    let view_buttons = this.getViewButtons().map(item => {
+	      let view_class = 'hover-shade';
+	      if (item.type == this.state.view_type) view_class += ' active';
+	      return /*#__PURE__*/reactExports.createElement("a", {
+	        id: 'button_' + item.type,
+	        className: view_class,
+	        onClick: this.changeView.bind(this, item.type)
+	      }, item.name);
+	    });
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "project-menu"
+	    }, /*#__PURE__*/reactExports.createElement("div", {
+	      className: "project-header"
+	    }, /*#__PURE__*/reactExports.createElement(WorkflowForMenu, {
+	      no_hyperlink: true,
+	      workflow_data: this.state.liveproject,
+	      selectAction: this.openEdit.bind(this)
+	    }), this.getHeader()), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-view-select hide-print"
+	    }, view_buttons), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-container"
+	    }, this.getContent()), reactDomExports.createPortal(overflow_links, $('#overflow-links')[0]));
+	  }
+	}
+
+	class StudentLiveProjectOverview extends LiveProjectSection {
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    let workflows = this.state.data.workflows.map(workflow => /*#__PURE__*/reactExports.createElement(SimpleWorkflow$1, {
+	      workflow_data: workflow
+	    }));
+	    if (workflows.length == 0) workflows = gettext('No workflows have been made visible to students.');
+	    let assignments = this.state.data.assignments.filter(assignment => assignment.user_assignment.completed == false).map(assignment => /*#__PURE__*/reactExports.createElement("tr", null, /*#__PURE__*/reactExports.createElement("td", null, /*#__PURE__*/reactExports.createElement(AssignmentTitle, {
+	      data: assignment,
+	      user_role: this.props.renderer.user_role
+	    })), /*#__PURE__*/reactExports.createElement("td", null, /*#__PURE__*/reactExports.createElement("input", {
+	      type: "checkbox",
+	      disabled: !assignment.self_reporting,
+	      onChange: this.toggleAssignment.bind(this, assignment.user_assignment.id)
+	    })), /*#__PURE__*/reactExports.createElement("td", null, /*#__PURE__*/reactExports.createElement(DatePicker, {
+	      default_value: assignment.end_date,
+	      disabled: true
+	    }))));
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Your Incomplete Assignments'), ":"), /*#__PURE__*/reactExports.createElement("table", {
+	      className: "overview-table"
+	    }, /*#__PURE__*/reactExports.createElement("tr", null, /*#__PURE__*/reactExports.createElement("th", null, gettext('Assignment')), /*#__PURE__*/reactExports.createElement("th", null, gettext('Completion')), /*#__PURE__*/reactExports.createElement("th", null, gettext('End Date'))), assignments), /*#__PURE__*/reactExports.createElement("h3", null, gettext('Visible Workflows'), ":"), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "menu-grid"
+	    }, workflows));
+	  }
+	  toggleAssignment(id, evt) {
+	    setAssignmentCompletion(id, evt.target.checked);
+	  }
+	}
+
+	/**
+	 *
+	 */
+	class StudentLiveProjectWorkflows extends LiveProjectSection {
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    let workflows_added = this.state.data.workflows_added.map(workflow => /*#__PURE__*/reactExports.createElement(WorkflowForMenu, {
+	      workflow_data: workflow
+	    }));
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Workflows')), /*#__PURE__*/reactExports.createElement("div", {
+	      className: "menu-grid"
+	    }, workflows_added));
+	  }
+	}
+
+	/**
+	 *
+	 */
+	class StudentLiveProjectAssignments extends LiveProjectSection {
+	  render() {
+	    if (!this.state.data) return this.defaultRender();
+	    let assignments_past = this.state.data.assignments_past.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
+	      renderer: this.props.renderer,
+	      data: assignment
+	    }));
+	    let assignments_upcoming = this.state.data.assignments_upcoming.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
+	      renderer: this.props.renderer,
+	      data: assignment
+	    }));
+	    return /*#__PURE__*/reactExports.createElement("div", {
+	      className: "workflow-details"
+	    }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Your Tasks'), ":"), /*#__PURE__*/reactExports.createElement("h4", null, gettext('Upcoming'), ":"), /*#__PURE__*/reactExports.createElement("div", null, assignments_upcoming), /*#__PURE__*/reactExports.createElement("h4", null, gettext('Past'), ":"), /*#__PURE__*/reactExports.createElement("div", null, assignments_past));
+	  }
+	}
+
+	/**
+	 *
+	 */
+	class StudentLiveProjectMenu extends LiveProjectMenu {
+	  getViewButtons() {
+	    return [{
+	      type: 'overview',
+	      name: gettext('Classroom Overview')
+	    }, {
+	      type: 'assignments',
+	      name: gettext('My Assignments')
+	    }, {
+	      type: 'workflows',
+	      name: gettext('My Workflows')
+	    }];
+	  }
+	  getRole() {
+	    return 'student';
+	  }
+	  getContent() {
+	    switch (this.state.view_type) {
+	      case 'overview':
+	        return /*#__PURE__*/reactExports.createElement(StudentLiveProjectOverview, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'assignments':
+	        return /*#__PURE__*/reactExports.createElement(StudentLiveProjectAssignments, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	      case 'workflows':
+	        return /*#__PURE__*/reactExports.createElement(StudentLiveProjectWorkflows, {
+	          renderer: this.props.renderer,
+	          role: this.getRole(),
+	          objectID: this.props.project.id,
+	          view_type: this.state.view_type
+	        });
+	    }
+	  }
+	  updateFunction(new_state) {
+	    this.setState(new_state);
+	  }
+	}
 
 	/**
 	 * @TODO why is this different than scripts-library.js

--- a/course_flow/static/course_flow/js/react/dist/scripts-live.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-live.min.js
@@ -33997,6 +33997,7 @@ var live_renderers = (function (exports) {
 	    if (this.state.favourite) fav_class = ' filled';
 	    let buttons = [];
 	    if (this.props.workflow_data.type !== 'liveproject') buttons.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "btn-workflow-toggle-favourite",
 	      className: "workflow-toggle-favourite hover-shade",
 	      onClick: evt => {
 	        toggleFavourite(this.props.workflow_data.id, this.props.workflow_data.type, !this.state.favourite);
@@ -34012,15 +34013,18 @@ var live_renderers = (function (exports) {
 	    }, "star")));
 	    let workflows = [];
 	    if (this.props.workflow_data.type === 'project' && !(this.props.workflow_data.workflow_count == null)) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "workflow-created-count",
 	      className: "workflow-created"
 	    }, this.props.workflow_data.workflow_count + ' ' + gettext('workflows')));
 	    if (this.props.workflow_data.type == 'project' && this.props.workflow_data.has_liveproject && this.props.workflow_data.object_permission.role_type !== role_keys['none']) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "workflow-created-group",
 	      className: "workflow-created workflow-live-classroom"
 	    }, /*#__PURE__*/reactExports.createElement("span", {
 	      className: "material-symbols-rounded small-inline",
 	      title: gettext('Live Classroom')
 	    }, "group"), ' ' + gettext('Live Classroom')));
 	    if (this.props.workflow_data.is_linked) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+	      key: "workflow-created-warning",
 	      className: "workflow-created linked-workflow-warning",
 	      title: gettext('Warning: linking the same workflow to multiple nodes can result in loss of readability if you are associating parent workflow outcomes with child workflow outcomes.')
 	    }, /*#__PURE__*/reactExports.createElement("span", {

--- a/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
@@ -48611,7 +48611,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  }, /*#__PURE__*/React.createElement(ListItemButton$1, {
 	    component: "a",
 	    href: favourite.url,
-	    class: "panel-favourite hover-shade",
+	    "data-test-id": "panel-favourite",
 	    selected: window.location.pathname === favourite.url
 	  }, /*#__PURE__*/React.createElement(ListItemText$1, {
 	    primary: favourite.title

--- a/course_flow/static/course_flow/js/react/dist/scripts-wf-redux.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-wf-redux.min.js
@@ -37763,6 +37763,7 @@ var renderers = (function (exports) {
       if (this.props.no_hyperlink || data.url == 'noaccess' || data.url == 'nouser') {
         return /*#__PURE__*/reactExports.createElement("div", {
           className: this.props.class_name,
+          "data-test-id": this.props.test_id,
           title: text,
           dangerouslySetInnerHTML: {
             __html: text
@@ -37773,6 +37774,7 @@ var renderers = (function (exports) {
           onClick: evt => evt.stopPropagation(),
           href: href,
           className: this.props.class_name,
+          "data-test-id": this.props.test_id,
           title: text,
           dangerouslySetInnerHTML: {
             __html: text
@@ -40291,248 +40293,6 @@ var renderers = (function (exports) {
     }
   }
 
-  class AssignmentViewSmall extends reactExports.Component {
-    render() {
-      let data = this.props.data;
-      let node_data = data.task;
-      let css_class = 'node assignment';
-      let style = {
-        backgroundColor: getColumnColour(node_data)
-      };
-      return /*#__PURE__*/reactExports.createElement("div", {
-        style: style,
-        className: css_class
-      }, /*#__PURE__*/reactExports.createElement("div", {
-        className: "node-top-row"
-      }, /*#__PURE__*/reactExports.createElement(AssignmentTitle, {
-        user_role: this.props.renderer.user_role,
-        data: data
-      })));
-    }
-  }
-
-  class AssignmentWorkflowNodesDisplay extends reactExports.Component {
-    constructor(props) {
-      super(props);
-      this.state = {};
-    }
-
-    /*******************************************************
-     * LIFECYCLE
-     *******************************************************/
-    componentDidMount() {
-      this.getData();
-    }
-    componentDidUpdate(prevProps) {
-      if (prevProps.objectID != this.props.objectID) {
-        this.setState({
-          data: null
-        }, this.getData.bind(this));
-      }
-    }
-
-    /*******************************************************
-     * RENDER
-     *******************************************************/
-    getData() {
-      let component = this;
-      getWorkflowNodes(this.props.objectID, data => {
-        component.setState({
-          data: data.data_package
-        });
-      });
-    }
-    defaultRender() {
-      // @todo undefined scope error
-      return /*#__PURE__*/reactExports.createElement(renderers.WorkflowLoader, null);
-    }
-
-    /*******************************************************
-     * RENDER
-     *******************************************************/
-    render() {
-      if (!this.state.data) return this.defaultRender();
-      let weeks = this.state.data.weeks.map((week, i) => {
-        let nodes = week.nodes.map(node => /*#__PURE__*/reactExports.createElement(AssignmentNode, {
-          renderer: this.props.renderer,
-          data: node
-        }));
-        let default_text;
-        default_text = week.week_type_display + ' ' + (i + 1);
-        return /*#__PURE__*/reactExports.createElement("div", {
-          className: "week"
-        }, /*#__PURE__*/reactExports.createElement(TitleText, {
-          text: week.title,
-          defaultText: default_text
-        }), /*#__PURE__*/reactExports.createElement("div", {
-          className: "node-block-grid"
-        }, nodes));
-      });
-      return /*#__PURE__*/reactExports.createElement("div", null, weeks);
-    }
-  }
-  class AssignmentNode extends reactExports.Component {
-    render() {
-      let data = this.props.data;
-      let lefticon;
-      let righticon;
-      if (data.context_classification > 0) lefticon = /*#__PURE__*/reactExports.createElement("img", {
-        title: renderer.context_choices.find(obj => obj.type == data.context_classification).name,
-        src: config.icon_path + context_keys[data.context_classification] + '.svg'
-      });
-      if (data.task_classification > 0) righticon = /*#__PURE__*/reactExports.createElement("img", {
-        title: renderer.task_choices.find(obj => obj.type == data.task_classification).name,
-        src: config.icon_path + task_keys[data.task_classification] + '.svg'
-      });
-      let style = {
-        backgroundColor: getColumnColour(this.props.data)
-      };
-      let mouseover_actions = [this.addCreateAssignment(data)];
-      return /*#__PURE__*/reactExports.createElement("div", {
-        style: style,
-        className: "node"
-      }, /*#__PURE__*/reactExports.createElement("div", {
-        className: "mouseover-actions"
-      }, mouseover_actions), /*#__PURE__*/reactExports.createElement("div", {
-        className: "node-top-row"
-      }, /*#__PURE__*/reactExports.createElement("div", {
-        className: "node-icon"
-      }, lefticon), /*#__PURE__*/reactExports.createElement(NodeTitle, {
-        data: this.props.data
-      }), /*#__PURE__*/reactExports.createElement("div", {
-        className: "node-icon"
-      }, righticon)), /*#__PURE__*/reactExports.createElement("div", {
-        className: "node-drop-row"
-      }));
-    }
-    addCreateAssignment(data) {
-      return /*#__PURE__*/reactExports.createElement(ActionButton, {
-        button_icon: "assignment.svg",
-        button_class: "duplicate-self-button",
-        titletext: gettext('Create Assignment'),
-        handleClick: this.createAssignment.bind(this, data)
-      });
-    }
-    createAssignment(data) {
-      let props = this.props;
-      props.renderer.tiny_loader.startLoad();
-      createAssignment(data.id, props.renderer.project_data.id, response_data => {
-        props.renderer.tiny_loader.endLoad();
-        window.location = config.update_path.liveassignment.replace('0', response_data.assignmentPk);
-      });
-    }
-  }
-  class LiveProjectAssignments extends LiveProjectSection {
-    changeView(workflow_id) {
-      this.setState({
-        selected_id: workflow_id
-      });
-    }
-
-    /*******************************************************
-     * RENDER
-     *******************************************************/
-    render() {
-      if (!this.state.data) return this.defaultRender();
-      let assignments = this.state.data.assignments.map(assignment => /*#__PURE__*/reactExports.createElement(AssignmentView, {
-        renderer: this.props.renderer,
-        data: assignment
-      }));
-      let workflow_options = this.state.data.workflows.map(workflow => {
-        let view_class = 'hover-shade';
-        if (workflow.id == this.state.selected_id) view_class += ' active';
-        return /*#__PURE__*/reactExports.createElement("div", {
-          id: 'button_' + workflow.id,
-          className: view_class,
-          onClick: this.changeView.bind(this, workflow.id)
-        }, /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
-          no_hyperlink: true,
-          data: workflow
-        }));
-      });
-      let workflow_nodes;
-      if (this.state.selected_id) {
-        workflow_nodes = /*#__PURE__*/reactExports.createElement(AssignmentWorkflowNodesDisplay, {
-          renderer: this.props.renderer,
-          objectID: this.state.selected_id
-        });
-      }
-      return /*#__PURE__*/reactExports.createElement("div", {
-        className: "workflow-details"
-      }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Assigned Tasks')), /*#__PURE__*/reactExports.createElement("div", null, assignments), /*#__PURE__*/reactExports.createElement("h3", null, gettext('All Tasks')), /*#__PURE__*/reactExports.createElement("div", {
-        id: "select-workflow",
-        className: "workflow-view-select"
-      }, workflow_options), workflow_nodes);
-    }
-  }
-  LiveProjectAssignments;
-
-  class LiveProjectCompletionTable extends LiveProjectSection {
-    render() {
-      if (!this.state.data) return this.defaultRender();
-      this.state.liveproject;
-      let head = this.state.data.assignments.map(assignment => /*#__PURE__*/reactExports.createElement("th", {
-        className: "table-cell nodewrapper"
-      }, /*#__PURE__*/reactExports.createElement(AssignmentViewSmall, {
-        renderer: this.props.renderer,
-        data: assignment
-      })));
-      let assignment_ids = this.state.data.assignments.map(assignment => assignment.id);
-      let body = this.state.data.table_rows.map((row, row_index) => /*#__PURE__*/reactExports.createElement("tr", {
-        className: "outcome-row"
-      }, /*#__PURE__*/reactExports.createElement("td", {
-        className: "user-head outcome-head"
-      }, getUserDisplay(row.user)), assignment_ids.map(id => {
-        let assignment = row.assignments.find(row_element => row_element.assignment == id);
-        if (!assignment) return /*#__PURE__*/reactExports.createElement("td", {
-          className: "table-cell"
-        });
-        return /*#__PURE__*/reactExports.createElement("td", {
-          className: "table-cell"
-        }, /*#__PURE__*/reactExports.createElement("input", {
-          onChange: this.toggleCompletion.bind(this, assignment.id, row_index),
-          type: "checkbox",
-          checked: assignment.completed
-        }));
-      }), /*#__PURE__*/reactExports.createElement("td", {
-        className: "table-cell total-cell grand-total-cell"
-      }, row.assignments.reduce((total, assignment) => total + assignment.completed, 0) + '/' + row.assignments.length)));
-      return /*#__PURE__*/reactExports.createElement("div", {
-        className: "workflow-details"
-      }, /*#__PURE__*/reactExports.createElement("h3", null, gettext('Table'), ":"), /*#__PURE__*/reactExports.createElement("table", {
-        className: "user-table outcome-table node-rows"
-      }, /*#__PURE__*/reactExports.createElement("tr", {
-        className: "outcome-row node-row"
-      }, /*#__PURE__*/reactExports.createElement("th", {
-        className: "user-head outcome-head empty"
-      }), head, /*#__PURE__*/reactExports.createElement("th", {
-        className: "table-cell nodewrapper total-cell grand-total-cell"
-      }, /*#__PURE__*/reactExports.createElement("div", {
-        className: "total-header"
-      }, gettext('Total'), ":"))), body));
-    }
-    toggleCompletion(id, row_index, evt) {
-      setAssignmentCompletion(id, evt.target.checked);
-      let new_data = {
-        ...this.state.data
-      };
-      new_data.table_rows = new_data.table_rows.slice();
-      new_data.table_rows[row_index] = {
-        ...new_data.table_rows[row_index]
-      };
-      new_data.table_rows[row_index].assignments = new_data.table_rows[row_index].assignments.slice();
-      let index = new_data.table_rows[row_index].assignments.findIndex(assignment => assignment.id == id);
-      new_data.table_rows[row_index].assignments[index] = {
-        ...new_data.table_rows[row_index].assignments[index],
-        completed: evt.target.checked
-      };
-      this.setState({
-        data: new_data
-      });
-    }
-  }
-  LiveProjectCompletionTable;
-
   class LiveProjectSettings extends LiveProjectSection {
     constructor(props) {
       super(props);
@@ -40627,7 +40387,6 @@ var renderers = (function (exports) {
       }, gettext('Save classroom changes'))));
     }
   }
-  var LiveProjectSettings$1 = LiveProjectSettings;
 
   class MenuSection extends reactExports.Component {
     constructor(props) {
@@ -41062,7 +40821,7 @@ var renderers = (function (exports) {
     }
     getLiveProjectSettings() {
       if (this.props.data.renderer.user_role === role_keys.teacher) {
-        return /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement(LiveProjectSettings$1, {
+        return /*#__PURE__*/reactExports.createElement("div", null, /*#__PURE__*/reactExports.createElement(LiveProjectSettings, {
           renderer: this.props.renderer,
           role: 'teacher',
           objectID: this.state.id,
@@ -41529,6 +41288,35 @@ var renderers = (function (exports) {
     }
   }
 
+  //Removes the specified comment from the object
+  function removeComment(objectID, objectType, commentPk, callBackFunction = () => console.log('success')) {
+    try {
+      $.post(config.post_paths.remove_comment, {
+        objectID: JSON.stringify(objectID),
+        commentPk: JSON.stringify(commentPk),
+        objectType: JSON.stringify(objectType)
+      }).done(function (data) {
+        if (data.action === DATA_ACTIONS.POSTED) callBackFunction(data);else fail_function(data.action);
+      });
+    } catch (err) {
+      fail_function();
+    }
+  }
+
+  //Removes all comments from the object
+  function removeAllComments(objectID, objectType, callBackFunction = () => console.log('success')) {
+    try {
+      $.post(config.post_paths.remove_all_comments, {
+        objectID: JSON.stringify(objectID),
+        objectType: JSON.stringify(objectType)
+      }).done(function (data) {
+        if (data.action === DATA_ACTIONS.POSTED) callBackFunction(data);else fail_function(data.action);
+      });
+    } catch (err) {
+      fail_function();
+    }
+  }
+
   //Causes the specified throughmodel to update its degree
   function updateOutcomenodeDegree(nodeID, outcomeID, value, callBackFunction = () => console.log('success')) {
     try {
@@ -41974,19 +41762,6 @@ var renderers = (function (exports) {
       $.post(config.post_paths.get_live_project_data_student, {
         liveprojectPk: JSON.stringify(projectPk),
         data_type: JSON.stringify(data_type)
-      }).done(function (data) {
-        if (data.action === DATA_ACTIONS.POSTED) callBackFunction(data);else fail_function(data.action);
-      });
-    } catch (err) {
-      fail_function();
-    }
-  }
-
-  //get nodes for the workflow
-  function getWorkflowNodes(workflowPk, callBackFunction = () => console.log('success')) {
-    try {
-      $.post(config.post_paths.get_workflow_nodes, {
-        workflowPk: JSON.stringify(workflowPk)
       }).done(function (data) {
         if (data.action === DATA_ACTIONS.POSTED) callBackFunction(data);else fail_function(data.action);
       });
@@ -72859,16 +72634,20 @@ var renderers = (function (exports) {
     render() {
       if (this.state.has_loaded) {
         if (this.state.parent_workflows.length == 0 && this.props.child_workflows.length == 0) return null;
-        let parent_workflows = this.state.parent_workflows.map(parent_workflow => /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
+        let parent_workflows = this.state.parent_workflows.map((parent_workflow, index) => /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
+          key: index,
           data: parent_workflow,
-          class_name: 'panel-favourite'
+          test_id: "panel-favourite"
         }));
         let child_workflows = this.props.child_workflows.map((child_workflow, index) => /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
           key: index,
           data: child_workflow,
-          class_name: 'panel-favourite'
+          test_id: "panel-favourite"
         }));
-        let return_val = [/*#__PURE__*/reactExports.createElement("hr", null), /*#__PURE__*/reactExports.createElement("a", {
+        let return_val = [/*#__PURE__*/reactExports.createElement("hr", {
+          key: "br"
+        }), /*#__PURE__*/reactExports.createElement("a", {
+          key: "quick-nav",
           className: "panel-item"
         }, gettext('Quick Navigation'))];
         if (parent_workflows.length > 0) return_val.push( /*#__PURE__*/reactExports.createElement("a", {

--- a/course_flow/static/course_flow/js/react/dist/scripts-wf-redux.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-wf-redux.min.js
@@ -37616,6 +37616,7 @@ var renderers = (function (exports) {
       if (this.state.favourite) fav_class = ' filled';
       let buttons = [];
       if (this.props.workflow_data.type !== 'liveproject') buttons.push( /*#__PURE__*/reactExports.createElement("div", {
+        key: "btn-workflow-toggle-favourite",
         className: "workflow-toggle-favourite hover-shade",
         onClick: evt => {
           toggleFavourite(this.props.workflow_data.id, this.props.workflow_data.type, !this.state.favourite);
@@ -37631,15 +37632,18 @@ var renderers = (function (exports) {
       }, "star")));
       let workflows = [];
       if (this.props.workflow_data.type === 'project' && !(this.props.workflow_data.workflow_count == null)) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+        key: "workflow-created-count",
         className: "workflow-created"
       }, this.props.workflow_data.workflow_count + ' ' + gettext('workflows')));
       if (this.props.workflow_data.type == 'project' && this.props.workflow_data.has_liveproject && this.props.workflow_data.object_permission.role_type !== role_keys['none']) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+        key: "workflow-created-group",
         className: "workflow-created workflow-live-classroom"
       }, /*#__PURE__*/reactExports.createElement("span", {
         className: "material-symbols-rounded small-inline",
         title: gettext('Live Classroom')
       }, "group"), ' ' + gettext('Live Classroom')));
       if (this.props.workflow_data.is_linked) workflows.push( /*#__PURE__*/reactExports.createElement("div", {
+        key: "workflow-created-warning",
         className: "workflow-created linked-workflow-warning",
         title: gettext('Warning: linking the same workflow to multiple nodes can result in loss of readability if you are associating parent workflow outcomes with child workflow outcomes.')
       }, /*#__PURE__*/reactExports.createElement("span", {
@@ -72147,8 +72151,8 @@ var renderers = (function (exports) {
     getJump() {
       if (this.props.renderer.view_type != 'workflowview') return null;
       let data = this.props.data;
-      let nodebarweekworkflows = data.weekworkflow_set.map(weekworkflow => /*#__PURE__*/reactExports.createElement(NodeBarWeekWorkflow, {
-        key: weekworkflow,
+      let nodebarweekworkflows = data.weekworkflow_set.map((weekworkflow, index) => /*#__PURE__*/reactExports.createElement(NodeBarWeekWorkflow, {
+        key: `weekworkflow-${index}`,
         order: data.weekworkflow_set,
         renderer: this.props.renderer,
         objectID: weekworkflow
@@ -72230,15 +72234,15 @@ var renderers = (function (exports) {
     render() {
       let data = this.props.data;
       let renderer = this.props.renderer;
-      var columnworkflows = data.columnworkflow_set.map(columnworkflow => /*#__PURE__*/reactExports.createElement(ColumnWorkflowView$1, {
-        key: columnworkflow,
+      var columnworkflows = data.columnworkflow_set.map((columnworkflow, index) => /*#__PURE__*/reactExports.createElement(ColumnWorkflowView$1, {
+        key: `columnworkflow-${index}`,
         objectID: columnworkflow,
         parentID: data.id,
         renderer: renderer
       }));
-      var weekworkflows = data.weekworkflow_set.map(weekworkflow => /*#__PURE__*/reactExports.createElement(WeekWorkflowView$1, {
+      var weekworkflows = data.weekworkflow_set.map((weekworkflow, index) => /*#__PURE__*/reactExports.createElement(WeekWorkflowView$1, {
         condensed: data.condensed,
-        key: weekworkflow,
+        key: `weekworkflow-${index}`,
         objectID: weekworkflow,
         parentID: data.id,
         renderer: renderer
@@ -72396,8 +72400,8 @@ var renderers = (function (exports) {
     }
     render() {
       let data = this.props.data;
-      var nodebarcolumnworkflows = data.columnworkflow_set.map(columnworkflow => /*#__PURE__*/reactExports.createElement(NodeBarColumnWorkflow, {
-        key: columnworkflow,
+      var nodebarcolumnworkflows = data.columnworkflow_set.map((columnworkflow, index) => /*#__PURE__*/reactExports.createElement(NodeBarColumnWorkflow, {
+        key: `NodeBarColumnWorkflow-${index}`,
         renderer: this.props.renderer,
         objectID: columnworkflow
       }));
@@ -72405,14 +72409,14 @@ var renderers = (function (exports) {
       for (var i = 0; i < data.DEFAULT_COLUMNS.length; i++) {
         if (columns_present.indexOf(data.DEFAULT_COLUMNS[i]) < 0) {
           nodebarcolumnworkflows.push( /*#__PURE__*/reactExports.createElement(NodeBarColumnWorkflow, {
-            key: 'default' + i,
+            key: `NodeBarColumnWorkflow-${i}`,
             renderer: this.props.renderer,
             columnType: data.DEFAULT_COLUMNS[i]
           }));
         }
       }
       nodebarcolumnworkflows.push( /*#__PURE__*/reactExports.createElement(NodeBarColumnWorkflow, {
-        key: 'default' + i,
+        key: `NodeBarColumnWorkflow-last-${i}`,
         renderer: this.props.renderer,
         columnType: data.DEFAULT_CUSTOM_COLUMN
       }));
@@ -72635,12 +72639,12 @@ var renderers = (function (exports) {
       if (this.state.has_loaded) {
         if (this.state.parent_workflows.length == 0 && this.props.child_workflows.length == 0) return null;
         let parent_workflows = this.state.parent_workflows.map((parent_workflow, index) => /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
-          key: index,
+          key: `WorkflowTitleParent-${index}`,
           data: parent_workflow,
           test_id: "panel-favourite"
         }));
         let child_workflows = this.props.child_workflows.map((child_workflow, index) => /*#__PURE__*/reactExports.createElement(WorkflowTitle$1, {
-          key: index,
+          key: `WorkflowTitleChild-${index}`,
           data: child_workflow,
           test_id: "panel-favourite"
         }));

--- a/course_flow/static/course_flow/js/react/src/Components/Library/HomeMenu.js
+++ b/course_flow/static/course_flow/js/react/src/Components/Library/HomeMenu.js
@@ -25,11 +25,19 @@ class HomeMenu extends React.Component {
    * Render
    *******************************************************/
   render() {
-    let projects = this.state.projects.map((project) => (
-      <WorkflowForMenu workflow_data={project} renderer={this.props.renderer} />
+    let projects = this.state.projects.map((project, index) => (
+      <WorkflowForMenu
+        key={`project-${index}`}
+        workflow_data={project}
+        renderer={this.props.renderer}
+      />
     ))
-    let favourites = this.state.favourites.map((project) => (
-      <WorkflowForMenu workflow_data={project} renderer={this.props.renderer} />
+    let favourites = this.state.favourites.map((project, index) => (
+      <WorkflowForMenu
+        key={`favourite-${index}`}
+        workflow_data={project}
+        renderer={this.props.renderer}
+      />
     ))
     let library_path = config.my_library_path
     if (!this.props.renderer.is_teacher)

--- a/course_flow/static/course_flow/js/react/src/Components/Library/WorkflowForMenu.js
+++ b/course_flow/static/course_flow/js/react/src/Components/Library/WorkflowForMenu.js
@@ -44,6 +44,7 @@ class WorkflowForMenu extends React.Component {
     if (this.props.workflow_data.type !== 'liveproject')
       buttons.push(
         <div
+          key="btn-workflow-toggle-favourite"
           className="workflow-toggle-favourite hover-shade"
           onClick={(evt) => {
             toggleFavourite(
@@ -70,7 +71,7 @@ class WorkflowForMenu extends React.Component {
       !(this.props.workflow_data.workflow_count == null)
     )
       workflows.push(
-        <div className="workflow-created">
+        <div key="workflow-created-count" className="workflow-created">
           {this.props.workflow_data.workflow_count + ' ' + gettext('workflows')}
         </div>
       )
@@ -81,7 +82,10 @@ class WorkflowForMenu extends React.Component {
         Constants.role_keys['none']
     )
       workflows.push(
-        <div className="workflow-created workflow-live-classroom">
+        <div
+          key="workflow-created-group"
+          className="workflow-created workflow-live-classroom"
+        >
           <span
             className="material-symbols-rounded small-inline"
             title={gettext('Live Classroom')}
@@ -94,6 +98,7 @@ class WorkflowForMenu extends React.Component {
     if (this.props.workflow_data.is_linked)
       workflows.push(
         <div
+          key="workflow-created-warning"
           className="workflow-created linked-workflow-warning"
           title={gettext(
             'Warning: linking the same workflow to multiple nodes can result in loss of readability if you are associating parent workflow outcomes with child workflow outcomes.'

--- a/course_flow/static/course_flow/js/react/src/Components/Views/WorkflowView.js
+++ b/course_flow/static/course_flow/js/react/src/Components/Views/WorkflowView.js
@@ -1376,25 +1376,28 @@ class ParentWorkflowIndicatorUnconnected extends React.Component {
       )
         return null
       let parent_workflows = this.state.parent_workflows.map(
-        (parent_workflow) => (
+        (parent_workflow, index) => (
           <WorkflowTitle
+            key={`parent-${index}`}
             data={parent_workflow}
-            class_name={'panel-favourite'}
+            test_id="panel-favourite"
           />
         )
       )
       let child_workflows = this.props.child_workflows.map(
         (child_workflow, index) => (
           <WorkflowTitle
-            key={index}
+            key={`child-${index}`}
             data={child_workflow}
-            class_name={'panel-favourite'}
+            test_id="panel-favourite"
           />
         )
       )
       let return_val = [
-        <hr />,
-        <a className="panel-item">{gettext('Quick Navigation')}</a>
+        <hr key="br" />,
+        <a key="quick-nav" className="panel-item">
+          {gettext('Quick Navigation')}
+        </a>
       ]
       if (parent_workflows.length > 0)
         return_val.push(

--- a/course_flow/static/course_flow/js/react/src/Components/Views/WorkflowView.js
+++ b/course_flow/static/course_flow/js/react/src/Components/Views/WorkflowView.js
@@ -660,14 +660,16 @@ class WorkflowBaseViewUnconnected extends EditableComponentWithActions {
   getJump() {
     if (this.props.renderer.view_type != 'workflowview') return null
     let data = this.props.data
-    let nodebarweekworkflows = data.weekworkflow_set.map((weekworkflow) => (
-      <NodeBarWeekWorkflow
-        key={weekworkflow}
-        order={data.weekworkflow_set}
-        renderer={this.props.renderer}
-        objectID={weekworkflow}
-      />
-    ))
+    let nodebarweekworkflows = data.weekworkflow_set.map(
+      (weekworkflow, index) => (
+        <NodeBarWeekWorkflow
+          key={`weekworkflow-${index}`}
+          order={data.weekworkflow_set}
+          renderer={this.props.renderer}
+          objectID={weekworkflow}
+        />
+      )
+    )
     return (
       <div id="jump-to">
         <div className="hover-shade flex-middle">
@@ -774,18 +776,20 @@ class WorkflowViewUnconnected extends EditableComponentWithSorting {
   render() {
     let data = this.props.data
     let renderer = this.props.renderer
-    var columnworkflows = data.columnworkflow_set.map((columnworkflow) => (
-      <ColumnWorkflowView
-        key={columnworkflow}
-        objectID={columnworkflow}
-        parentID={data.id}
-        renderer={renderer}
-      />
-    ))
-    var weekworkflows = data.weekworkflow_set.map((weekworkflow) => (
+    var columnworkflows = data.columnworkflow_set.map(
+      (columnworkflow, index) => (
+        <ColumnWorkflowView
+          key={`columnworkflow-${index}`}
+          objectID={columnworkflow}
+          parentID={data.id}
+          renderer={renderer}
+        />
+      )
+    )
+    var weekworkflows = data.weekworkflow_set.map((weekworkflow, index) => (
       <WeekWorkflowView
         condensed={data.condensed}
-        key={weekworkflow}
+        key={`weekworkflow-${index}`}
         objectID={weekworkflow}
         parentID={data.id}
         renderer={renderer}
@@ -1059,9 +1063,9 @@ class NodeBarUnconnected extends React.Component {
     let data = this.props.data
 
     var nodebarcolumnworkflows = data.columnworkflow_set.map(
-      (columnworkflow) => (
+      (columnworkflow, index) => (
         <NodeBarColumnWorkflow
-          key={columnworkflow}
+          key={`NodeBarColumnWorkflow-${index}`}
           renderer={this.props.renderer}
           objectID={columnworkflow}
         />
@@ -1072,7 +1076,7 @@ class NodeBarUnconnected extends React.Component {
       if (columns_present.indexOf(data.DEFAULT_COLUMNS[i]) < 0) {
         nodebarcolumnworkflows.push(
           <NodeBarColumnWorkflow
-            key={'default' + i}
+            key={`NodeBarColumnWorkflow-${i}`}
             renderer={this.props.renderer}
             columnType={data.DEFAULT_COLUMNS[i]}
           />
@@ -1081,7 +1085,7 @@ class NodeBarUnconnected extends React.Component {
     }
     nodebarcolumnworkflows.push(
       <NodeBarColumnWorkflow
-        key={'default' + i}
+        key={`NodeBarColumnWorkflow-last-${i}`}
         renderer={this.props.renderer}
         columnType={data.DEFAULT_CUSTOM_COLUMN}
       />
@@ -1378,7 +1382,7 @@ class ParentWorkflowIndicatorUnconnected extends React.Component {
       let parent_workflows = this.state.parent_workflows.map(
         (parent_workflow, index) => (
           <WorkflowTitle
-            key={`parent-${index}`}
+            key={`WorkflowTitleParent-${index}`}
             data={parent_workflow}
             test_id="panel-favourite"
           />
@@ -1387,7 +1391,7 @@ class ParentWorkflowIndicatorUnconnected extends React.Component {
       let child_workflows = this.props.child_workflows.map(
         (child_workflow, index) => (
           <WorkflowTitle
-            key={`child-${index}`}
+            key={`WorkflowTitleChild-${index}`}
             data={child_workflow}
             test_id="panel-favourite"
           />

--- a/course_flow/static/course_flow/js/react/src/Components/components/CommonComponents/EditableComponentWithComments.js
+++ b/course_flow/static/course_flow/js/react/src/Components/components/CommonComponents/EditableComponentWithComments.js
@@ -12,6 +12,7 @@ import * as Utility from '../../../UtilityFunctions.js'
 import { reloadCommentsAction } from '../../../redux/Reducers.js'
 // @components
 import Component from './Component.js'
+import EditableComponent from './EditableComponent.js'
 import ActionButton from './ActionButton.js'
 
 /*******************************************************

--- a/course_flow/static/course_flow/js/react/src/Components/components/CommonComponents/Titles.js
+++ b/course_flow/static/course_flow/js/react/src/Components/components/CommonComponents/Titles.js
@@ -49,6 +49,7 @@ export class WorkflowTitle extends React.Component {
       return (
         <div
           className={this.props.class_name}
+          data-test-id={this.props.test_id}
           title={text}
           dangerouslySetInnerHTML={{ __html: text }}
         />
@@ -59,6 +60,7 @@ export class WorkflowTitle extends React.Component {
           onClick={(evt) => evt.stopPropagation()}
           href={href}
           className={this.props.class_name}
+          data-test-id={this.props.test_id}
           title={text}
           dangerouslySetInnerHTML={{ __html: text }}
         />

--- a/course_flow/static/course_flow/js/react/src/Components/components/Layout/Sidebar.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/components/Layout/Sidebar.jsx
@@ -228,7 +228,7 @@ const Sidebar = () => {
                     <ListItemButton
                       component="a"
                       href={favourite.url}
-                      class="panel-favourite hover-shade"
+                      data-test-id="panel-favourite"
                       selected={window.location.pathname === favourite.url}
                     >
                       <ListItemText primary={favourite.title} />

--- a/course_flow/static/course_flow/scss/base_style.scss
+++ b/course_flow/static/course_flow/scss/base_style.scss
@@ -713,10 +713,6 @@ h3.big-space {
   background: $color-white-green;
 }
 
-.panel-favourite.active {
-  background: $color-white-green;
-}
-
 .panel-item > img,
 .panel-item .material-symbols-rounded {
   margin-right: 10px;
@@ -732,18 +728,6 @@ h3.big-space {
 
 .panel-item img {
   width: 24px;
-}
-
-.panel-favourite {
-  padding: 3px;
-  font-size: 13px;
-  display: block;
-  margin-left: 22px;
-  margin-right: 20px;
-  overflow: hidden;
-  -webkit-line-clamp: 1;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
 }
 
 .left-panel hr {

--- a/course_flow/tests/models/test_functional.py
+++ b/course_flow/tests/models/test_functional.py
@@ -3545,11 +3545,11 @@ class SeleniumDeleteRestoreTestCase(ChannelsStaticLiveServerTestCase):
         )
 
         wait.until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, ".panel-favourite"))
+            EC.element_to_be_clickable((By.CSS_SELECTOR, "[data-test-id='panel-favourite']"))
         )
 
         self.assertEqual(
-            len(selenium.find_elements(By.CSS_SELECTOR, ".panel-favourite")),
+            len(selenium.find_elements(By.CSS_SELECTOR, "[data-test-id='panel-favourite']")),
             2,
         )
 
@@ -3573,7 +3573,7 @@ class SeleniumDeleteRestoreTestCase(ChannelsStaticLiveServerTestCase):
         # make sure it doesn't show up in favourites
         time.sleep(1)
         self.assertEqual(
-            len(selenium.find_elements(By.CSS_SELECTOR, ".panel-favourite")),
+            len(selenium.find_elements(By.CSS_SELECTOR, "[data-test-id='panel-favourite']")),
             0,
         )
         self.assertEqual(


### PR DESCRIPTION
- Clean up unused class selectors for the sidebar, also removing the corresponding CSS styles that aren't used anywhere anymore
- Convert the sidebar class selectors to `data-test-id` attributes as the only thing consuming them is Selenium (and the new naming scheme makes it clear why/where they're used instead of confusing them with regular `id` or `class` selectors)
- Add missing key props to various components