### PR TITLE
Feature/notifications settings page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,5 +14,8 @@
   "plugins": [
     "react",
     "prettier"
-  ]
+  ],
+  "rules": {
+    "react/prop-types": "off"
+  }
 }

--- a/course_flow/forms.py
+++ b/course_flow/forms.py
@@ -51,3 +51,10 @@ class ProfileSettings(forms.ModelForm):
         widgets = {
             'language': forms.RadioSelect,
         }
+
+class NotificationsSettings(forms.ModelForm):
+    class Meta:
+        model = CourseFlowUser
+        fields = (
+            "notifications",
+        )

--- a/course_flow/serializers.py
+++ b/course_flow/serializers.py
@@ -2172,10 +2172,10 @@ class FormFieldsSerializer:
     # generate the list of choices for fields which have them
     def get_field_choices(self, field):
         choices = []
-        if hasattr(field, 'choices'):
+        if hasattr(field, "choices"):
             for choice in field.choices:
                 choices.append({
-                    "label": choice[1],
+                    "label": str(choice[1]),
                     "value": choice[0]
                 })
         return choices if len(choices) > 0 else None
@@ -2188,13 +2188,13 @@ class FormFieldsSerializer:
         if self.form_instance.is_valid():
             for field_name, field in self.form_instance.fields.items():
                 fields.append({
-                    "name": field_name,
-                    "label": field.label if hasattr(field, 'label') else None,
+                    "name": str(field_name),
+                    "label": str(field.label) if hasattr(field, 'label') else None,
                     "type": self.get_field_type(field),
                     "required": field.required,
                     "options": self.get_field_choices(field),
                     "max_length": field.max_length if hasattr(field, 'max_length') else None,
-                    "help_text": field.help_text if hasattr(field, 'help_text') else None,
+                    "help_text": str(field.help_text) if hasattr(field, 'help_text') else None,
                     "value": self.form_instance.cleaned_data.get(field_name, None),
                 })
         return fields

--- a/course_flow/static/course_flow/js/react/dist/course_flow.css
+++ b/course_flow/static/course_flow/js/react/dist/course_flow.css
@@ -1335,7 +1335,7 @@ h3.big-space {
   display: none; }
 
 .left-panel-extra {
-  overflow-y: overlay; }
+  overflow-y: auto; }
 
 .title-image {
   padding: 8px;
@@ -1451,7 +1451,7 @@ h3.big-space {
 .home-tabs > div {
   width: 100%;
   box-sizing: border-box;
-  overflow-y: overlay; }
+  overflow-y: auto; }
 
 .saltise-menu-container {
   height: 100%;
@@ -1459,7 +1459,7 @@ h3.big-space {
   background: #fff;
   padding: 50px;
   box-sizing: border-box;
-  overflow: overlay; }
+  overflow: auto; }
 
 .menu-create {
   padding: 8px;
@@ -1633,7 +1633,7 @@ h3.big-space {
   margin-bottom: 2px;
   white-space: pre-wrap;
   max-height: 140px;
-  overflow-y: overlay; }
+  overflow-y: auto; }
 
 .workflow-for-menu .workflow-description.collapsible-text {
   -webkit-line-clamp: 1;
@@ -1900,7 +1900,7 @@ h3.big-space {
   border: 1px solid #04ba74; }
 
 .explore-menu .explore-preview {
-  overflow-x: overlay; }
+  overflow-x: auto; }
 
 .explore-menu .explore-main {
   white-space: nowrap; }
@@ -2189,12 +2189,12 @@ h3.big-space {
 
 .message-wrap .home-tabs {
   height: calc(100% - 100px);
-  overflow-y: overlay; }
+  overflow-y: auto; }
 
 .message-wrap {
   width: 100%;
   height: 100%;
-  overflow-y: overlay;
+  overflow-y: auto;
   padding: 20px;
   padding-left: 40px;
   padding-right: 40px;
@@ -2335,7 +2335,7 @@ text {
   overflow: visible; }
 
 .body-wrapper {
-  overflow: overlay;
+  overflow: auto;
   flex-grow: 1;
   height: 100%;
   position: relative; }
@@ -3826,7 +3826,7 @@ div:hover > .mouseover-container-bypass > .mouseover-actions {
   border: 1px solid #04ba74;
   background: #fff;
   z-index: 7;
-  overflow: overlay;
+  overflow: auto;
   padding: 5px;
   font-size: 12px;
   box-sizing: border-box;
@@ -4136,7 +4136,7 @@ circle.mouseover {
   resize: none; }
 
 .right-panel-inner {
-  overflow-y: overlay;
+  overflow-y: auto;
   display: inline-block;
   padding: 20px;
   box-sizing: border-box;
@@ -4375,7 +4375,7 @@ circle.mouseover {
   background: #fff;
   height: 100%;
   padding: 20px;
-  overflow: overlay;
+  overflow: auto;
   vertical-align: top; }
 
 .action-bar {

--- a/course_flow/static/course_flow/js/react/dist/course_flow.css
+++ b/course_flow/static/course_flow/js/react/dist/course_flow.css
@@ -2338,7 +2338,8 @@ text {
   overflow: auto;
   flex-grow: 1;
   height: 100%;
-  position: relative; }
+  position: relative;
+  background-color: #fff; }
 
 .body-wrapper.printing {
   top: 0px;

--- a/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
@@ -52958,6 +52958,23 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}), 'MoreHoriz');
 	default_1$b = MoreHoriz.default = _default$b;
 
+	const OuterContentWrap = styled$1(Box$1, {
+	  shouldForwardProp: prop => prop !== 'narrow'
+	})(({
+	  theme,
+	  narrow
+	}) => ({
+	  padding: theme.spacing(8),
+	  paddingTop: 0,
+	  ...(narrow && {
+	    maxWidth: '34.25rem',
+	    marginLeft: 'auto',
+	    marginRight: 'auto',
+	    paddingLeft: theme.spacing(2),
+	    paddingRight: theme.spacing(2)
+	  })
+	}));
+
 	function useApi(url, debug = false) {
 	  const [state, setState] = reactExports.useState({
 	    loading: true,
@@ -57435,23 +57452,6 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    window.fail_function();
 	  }
 	}
-
-	const OuterContentWrap = styled$1(Box$1, {
-	  shouldForwardProp: prop => prop !== 'narrow'
-	})(({
-	  theme,
-	  narrow
-	}) => ({
-	  padding: theme.spacing(8),
-	  paddingTop: 0,
-	  ...(narrow && {
-	    maxWidth: '34.25rem',
-	    marginLeft: 'auto',
-	    marginRight: 'auto',
-	    paddingLeft: theme.spacing(2),
-	    paddingRight: theme.spacing(2)
-	  })
-	}));
 
 	const NotificationsWrap = styled$1(Box$1)({});
 	const NotificationsHeader$1 = styled$1(Box$1)(({

--- a/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
@@ -64487,32 +64487,23 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    width: '100%'
 	  }
 	});
-	const ProfileSettingsPage = () => {
+	const ProfileSettingsPage = ({
+	  formData
+	}) => {
+	  const [state, setState] = reactExports.useState(formData);
 	  const [errors, setErrors] = reactExports.useState({});
-	  const [formFields, setFormFields] = reactExports.useState(null);
 	  const [showSnackbar, setShowSnackbar] = reactExports.useState(false);
-	  const [apiData, loading, error] = useApi(COURSEFLOW_APP.config.json_api_paths.update_profile);
-
-	  // after the apiData is loaded in, set it as state so it can be used internally
-	  reactExports.useEffect(() => {
-	    if (!loading) {
-	      setFormFields(apiData.fields);
-	    }
-	  }, [loading]);
 	  function onFormSubmit() {
 	    const formData = {};
-	    formFields.map(field => formData[field.name] = field.value);
+	    state.map(field => formData[field.name] = field.value);
 	    API_POST(COURSEFLOW_APP.config.json_api_paths.update_profile, formData).then(() => setShowSnackbar(true)).catch(error => setErrors(error.data.errors));
 	  }
 	  function onSnackbarClose() {
 	    setShowSnackbar(false);
 	  }
-	  if (loading || error || !formFields) {
-	    return null;
-	  }
 
 	  // loop through all the fields and generate appropriate MUI input element
-	  const inputFields = formFields.map((field, idx) => {
+	  const inputFields = state.map((field, idx) => {
 	    const hasError = errors[field.name];
 	    const errorText = hasError && errors[field.name][0];
 	    switch (field.type) {
@@ -64531,14 +64522,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	          error: hasError,
 	          helperText: errorText,
 	          onChange: e => {
-	            const newFieldsState = [...formFields];
+	            const newFieldsState = [...state];
 	            newFieldsState[idx].value = e.target.value;
 	            const newErrors = {
 	              ...errors
 	            };
 	            delete newErrors[field.name];
 	            setErrors(newErrors);
-	            setFormFields(newFieldsState);
+	            setState(newFieldsState);
 	          }
 	        })));
 	      case 'radio':
@@ -64556,14 +64547,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	          value: field.value,
 	          name: field.name,
 	          onChange: e => {
-	            const newFieldsState = [...formFields];
+	            const newFieldsState = [...state];
 	            newFieldsState[idx].value = e.target.value;
 	            const newErrors = {
 	              ...errors
 	            };
 	            delete newErrors[field.name];
 	            setErrors(newErrors);
-	            setFormFields(newFieldsState);
+	            setState(newFieldsState);
 	          }
 	        }, field.options.map((option, idy) => /*#__PURE__*/React.createElement(FormControlLabel$1, {
 	          key: idy,
@@ -104634,7 +104625,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    case 'notificationsSettings':
 	      return /*#__PURE__*/React.createElement(NotificationsSettingsPage, COURSEFLOW_APP.contextData);
 	    case 'profileSettings':
-	      return /*#__PURE__*/React.createElement(ProfileSettingsPage, null);
+	      return /*#__PURE__*/React.createElement(ProfileSettingsPage, COURSEFLOW_APP.contextData);
 
 	    /*******************************************************
 	     * LIVE

--- a/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
@@ -58995,51 +58995,32 @@ Please use another name.` : formatMuiErrorMessage(18));
 	// with various different controls
 	function reducer(state, action) {
 	  switch (action.type) {
-	    case 'SET_INITIAL_STATE':
-	      return {
-	        ...state,
-	        ...action.payload
-	      };
 	    case 'SET_UPDATES':
 	      return {
 	        ...state,
-	        updates: action.value
+	        notifications: action.value
 	      };
 	  }
 	  return state;
 	}
-	const NotificationsSettingsPage = () => {
+	const NotificationsSettingsPage = ({
+	  formData
+	}) => {
 	  const [state, dispatch] = reactExports.useReducer(reducer, {
-	    updates: false
+	    notifications: formData.receiveNotifications
 	  });
-	  const [apiData, loading, error] = useApi(COURSEFLOW_APP.config.json_api_paths.update_notifications_settings);
-
-	  // after the apiData is loaded in, set it as state so it can be used internally
-	  reactExports.useEffect(() => {
-	    if (!loading) {
-	      dispatch({
-	        type: 'SET_INITIAL_STATE',
-	        payload: apiData
-	      });
-	    }
-	  }, [loading]);
-	  if (loading || error) {
-	    return null;
-	  }
 	  function onUpdatesSwitchChange(e) {
 	    const newState = {
 	      ...state,
-	      updates: !state.updates
+	      notifications: !state.notifications
 	    };
 
 	    // post to the appropriate URL
-	    API_POST(COURSEFLOW_APP.config.json_api_paths.update_notifications_settings, newState).then(response => {
-	      console.log('API_POST\n', newState, '\nto\n', COURSEFLOW_APP.config.json_api_paths.update_notifications_settings, '\ngot\n', response);
-
+	    API_POST(COURSEFLOW_APP.config.json_api_paths.update_notifications_settings, newState).then(() => {
 	      // and if successful, dispatch the action to update local state
 	      dispatch({
 	        type: 'SET_UPDATES',
-	        value: !state.updates
+	        value: newState.notifications
 	      });
 	    });
 	  }
@@ -59049,7 +59030,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    variant: "h1"
 	  }, COURSEFLOW_APP.strings.notification_settings)), /*#__PURE__*/React.createElement(FormGroup$1, null, /*#__PURE__*/React.createElement(FormControlLabel$1, {
 	    control: /*#__PURE__*/React.createElement(Switch$1, {
-	      checked: state.updates,
+	      checked: state.notifications,
 	      onChange: onUpdatesSwitchChange
 	    }),
 	    label: COURSEFLOW_APP.strings.product_updates_agree
@@ -104651,7 +104632,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    case 'notifications':
 	      return /*#__PURE__*/React.createElement(NotificationsPage, null);
 	    case 'notificationsSettings':
-	      return /*#__PURE__*/React.createElement(NotificationsSettingsPage, null);
+	      return /*#__PURE__*/React.createElement(NotificationsSettingsPage, COURSEFLOW_APP.contextData);
 	    case 'profileSettings':
 	      return /*#__PURE__*/React.createElement(ProfileSettingsPage, null);
 

--- a/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
+++ b/course_flow/static/course_flow/js/react/dist/scripts-redesign.min.js
@@ -9337,7 +9337,7 @@
 	  }
 	};
 
-	const _excluded$15 = ["values", "unit", "step"];
+	const _excluded$16 = ["values", "unit", "step"];
 	const sortBreakpointsValues = values => {
 	  const breakpointsAsArray = Object.keys(values).map(key => ({
 	    key,
@@ -9372,7 +9372,7 @@
 	      unit = 'px',
 	      step = 5
 	    } = breakpoints,
-	    other = _objectWithoutPropertiesLoose$1(breakpoints, _excluded$15);
+	    other = _objectWithoutPropertiesLoose$1(breakpoints, _excluded$16);
 	  const sortedValues = sortBreakpointsValues(values);
 	  const keys = Object.keys(sortedValues);
 	  function up(key) {
@@ -10468,7 +10468,7 @@
 	styleFunctionSx.filterProps = ['sx'];
 	var styleFunctionSx$1 = styleFunctionSx;
 
-	const _excluded$14 = ["breakpoints", "palette", "spacing", "shape"];
+	const _excluded$15 = ["breakpoints", "palette", "spacing", "shape"];
 	function createTheme$1(options = {}, ...args) {
 	  const {
 	      breakpoints: breakpointsInput = {},
@@ -10476,7 +10476,7 @@
 	      spacing: spacingInput,
 	      shape: shapeInput = {}
 	    } = options,
-	    other = _objectWithoutPropertiesLoose$1(options, _excluded$14);
+	    other = _objectWithoutPropertiesLoose$1(options, _excluded$15);
 	  const breakpoints = createBreakpoints(breakpointsInput);
 	  const spacing = createSpacing(spacingInput);
 	  let muiTheme = deepmerge({
@@ -10544,7 +10544,7 @@
 	  themeId: PropTypes.string
 	} : void 0;
 
-	const _excluded$13 = ["sx"];
+	const _excluded$14 = ["sx"];
 	const splitProps = props => {
 	  var _props$theme$unstable, _props$theme;
 	  const result = {
@@ -10565,7 +10565,7 @@
 	  const {
 	      sx: inSx
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$13);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$14);
 	  const {
 	    systemProps,
 	    otherProps
@@ -10589,7 +10589,7 @@
 	  });
 	}
 
-	const _excluded$12 = ["className", "component"];
+	const _excluded$13 = ["className", "component"];
 	function createBox(options = {}) {
 	  const {
 	    themeId,
@@ -10607,7 +10607,7 @@
 	        className,
 	        component = 'div'
 	      } = _extendSxProp,
-	      other = _objectWithoutPropertiesLoose$1(_extendSxProp, _excluded$12);
+	      other = _objectWithoutPropertiesLoose$1(_extendSxProp, _excluded$13);
 	    return /*#__PURE__*/jsxRuntimeExports.jsx(BoxRoot, _extends$2({
 	      as: component,
 	      ref: ref,
@@ -10618,7 +10618,7 @@
 	  return Box;
 	}
 
-	const _excluded$11 = ["variant"];
+	const _excluded$12 = ["variant"];
 	function isEmpty$3(string) {
 	  return string.length === 0;
 	}
@@ -10632,7 +10632,7 @@
 	  const {
 	      variant
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$11);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$12);
 	  let classKey = variant || '';
 	  Object.keys(other).sort().forEach(key => {
 	    if (key === 'color') {
@@ -10644,7 +10644,7 @@
 	  return classKey;
 	}
 
-	const _excluded$10 = ["name", "slot", "skipVariantsResolver", "skipSx", "overridesResolver"];
+	const _excluded$11 = ["name", "slot", "skipVariantsResolver", "skipSx", "overridesResolver"];
 	function isEmpty$2(obj) {
 	  return Object.keys(obj).length === 0;
 	}
@@ -10781,7 +10781,7 @@
 	        // For more details: https://github.com/mui/material-ui/pull/37908
 	        overridesResolver = defaultOverridesResolver(lowercaseFirstLetter(componentSlot))
 	      } = inputOptions,
-	      options = _objectWithoutPropertiesLoose$1(inputOptions, _excluded$10);
+	      options = _objectWithoutPropertiesLoose$1(inputOptions, _excluded$11);
 
 	    // if skipVariantsResolver option is defined, take the value, otherwise, true for root and false for other slots.
 	    const skipVariantsResolver = inputSkipVariantsResolver !== undefined ? inputSkipVariantsResolver :
@@ -11360,7 +11360,7 @@ The following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rg
 	  process.env.NODE_ENV !== "production" ? ThemeProvider$1.propTypes = exactProp(ThemeProvider$1.propTypes) : void 0;
 	}
 
-	const _excluded$$ = ["component", "direction", "spacing", "divider", "children", "className", "useFlexGap"];
+	const _excluded$10 = ["component", "direction", "spacing", "divider", "children", "className", "useFlexGap"];
 	const defaultTheme$3 = createTheme$1();
 	// widening Theme to any so that the consumer can own the theme structure.
 	const defaultCreateStyledComponent = systemStyled('div', {
@@ -11493,7 +11493,7 @@ The following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rg
 	        className,
 	        useFlexGap = false
 	      } = props,
-	      other = _objectWithoutPropertiesLoose$1(props, _excluded$$);
+	      other = _objectWithoutPropertiesLoose$1(props, _excluded$10);
 	    const ownerState = {
 	      direction,
 	      spacing,
@@ -11667,7 +11667,7 @@ The following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rg
 	};
 	var green$1 = green;
 
-	const _excluded$_ = ["mode", "contrastThreshold", "tonalOffset"];
+	const _excluded$$ = ["mode", "contrastThreshold", "tonalOffset"];
 	const light = {
 	  // The colors used to style the text.
 	  text: {
@@ -11836,7 +11836,7 @@ The following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rg
 	      contrastThreshold = 3,
 	      tonalOffset = 0.2
 	    } = palette,
-	    other = _objectWithoutPropertiesLoose$1(palette, _excluded$_);
+	    other = _objectWithoutPropertiesLoose$1(palette, _excluded$$);
 	  const primary = palette.primary || getDefaultPrimary(mode);
 	  const secondary = palette.secondary || getDefaultSecondary(mode);
 	  const error = palette.error || getDefaultError(mode);
@@ -11960,7 +11960,7 @@ const theme2 = createTheme({ palette: {
 	  return paletteOutput;
 	}
 
-	const _excluded$Z = ["fontFamily", "fontSize", "fontWeightLight", "fontWeightRegular", "fontWeightMedium", "fontWeightBold", "htmlFontSize", "allVariants", "pxToRem"];
+	const _excluded$_ = ["fontFamily", "fontSize", "fontWeightLight", "fontWeightRegular", "fontWeightMedium", "fontWeightBold", "htmlFontSize", "allVariants", "pxToRem"];
 	function round$1(value) {
 	  return Math.round(value * 1e5) / 1e5;
 	}
@@ -11991,7 +11991,7 @@ const theme2 = createTheme({ palette: {
 	      allVariants,
 	      pxToRem: pxToRem2
 	    } = _ref,
-	    other = _objectWithoutPropertiesLoose$1(_ref, _excluded$Z);
+	    other = _objectWithoutPropertiesLoose$1(_ref, _excluded$_);
 	  if (process.env.NODE_ENV !== 'production') {
 	    if (typeof fontSize !== 'number') {
 	      console.error('MUI: `fontSize` is required to be a number.');
@@ -12059,7 +12059,7 @@ const theme2 = createTheme({ palette: {
 	const shadows = ['none', createShadow(0, 2, 1, -1, 0, 1, 1, 0, 0, 1, 3, 0), createShadow(0, 3, 1, -2, 0, 2, 2, 0, 0, 1, 5, 0), createShadow(0, 3, 3, -2, 0, 3, 4, 0, 0, 1, 8, 0), createShadow(0, 2, 4, -1, 0, 4, 5, 0, 0, 1, 10, 0), createShadow(0, 3, 5, -1, 0, 5, 8, 0, 0, 1, 14, 0), createShadow(0, 3, 5, -1, 0, 6, 10, 0, 0, 1, 18, 0), createShadow(0, 4, 5, -2, 0, 7, 10, 1, 0, 2, 16, 1), createShadow(0, 5, 5, -3, 0, 8, 10, 1, 0, 3, 14, 2), createShadow(0, 5, 6, -3, 0, 9, 12, 1, 0, 3, 16, 2), createShadow(0, 6, 6, -3, 0, 10, 14, 1, 0, 4, 18, 3), createShadow(0, 6, 7, -4, 0, 11, 15, 1, 0, 4, 20, 3), createShadow(0, 7, 8, -4, 0, 12, 17, 2, 0, 5, 22, 4), createShadow(0, 7, 8, -4, 0, 13, 19, 2, 0, 5, 24, 4), createShadow(0, 7, 9, -4, 0, 14, 21, 2, 0, 5, 26, 4), createShadow(0, 8, 9, -5, 0, 15, 22, 2, 0, 6, 28, 5), createShadow(0, 8, 10, -5, 0, 16, 24, 2, 0, 6, 30, 5), createShadow(0, 8, 11, -5, 0, 17, 26, 2, 0, 6, 32, 5), createShadow(0, 9, 11, -5, 0, 18, 28, 2, 0, 7, 34, 6), createShadow(0, 9, 12, -6, 0, 19, 29, 2, 0, 7, 36, 6), createShadow(0, 10, 13, -6, 0, 20, 31, 3, 0, 8, 38, 7), createShadow(0, 10, 13, -6, 0, 21, 33, 3, 0, 8, 40, 7), createShadow(0, 10, 14, -6, 0, 22, 35, 3, 0, 8, 42, 7), createShadow(0, 11, 14, -7, 0, 23, 36, 3, 0, 9, 44, 8), createShadow(0, 11, 15, -7, 0, 24, 38, 3, 0, 9, 46, 8)];
 	var shadows$1 = shadows;
 
-	const _excluded$Y = ["duration", "easing", "delay"];
+	const _excluded$Z = ["duration", "easing", "delay"];
 	// Follow https://material.google.com/motion/duration-easing.html#duration-easing-natural-easing-curves
 	// to learn the context in which each easing should be used.
 	const easing = {
@@ -12110,7 +12110,7 @@ const theme2 = createTheme({ palette: {
 	        easing: easingOption = mergedEasing.easeInOut,
 	        delay = 0
 	      } = options,
-	      other = _objectWithoutPropertiesLoose$1(options, _excluded$Y);
+	      other = _objectWithoutPropertiesLoose$1(options, _excluded$Z);
 	    if (process.env.NODE_ENV !== 'production') {
 	      const isString = value => typeof value === 'string';
 	      // IE11 support, replace with Number.isNaN
@@ -12160,7 +12160,7 @@ const theme2 = createTheme({ palette: {
 	};
 	var zIndex$1 = zIndex;
 
-	const _excluded$X = ["breakpoints", "mixins", "spacing", "palette", "transitions", "typography", "shape"];
+	const _excluded$Y = ["breakpoints", "mixins", "spacing", "palette", "transitions", "typography", "shape"];
 	function createTheme(options = {}, ...args) {
 	  const {
 	      mixins: mixinsInput = {},
@@ -12168,7 +12168,7 @@ const theme2 = createTheme({ palette: {
 	      transitions: transitionsInput = {},
 	      typography: typographyInput = {}
 	    } = options,
-	    other = _objectWithoutPropertiesLoose$1(options, _excluded$X);
+	    other = _objectWithoutPropertiesLoose$1(options, _excluded$Y);
 	  if (options.vars) {
 	    throw new Error(process.env.NODE_ENV !== "production" ? `MUI: \`vars\` is a private field used for CSS variables support.
 Please use another name.` : formatMuiErrorMessage(18));
@@ -12314,8 +12314,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiScopedCssBaseline', ['root']);
 
-	const _excluded$W = ["className", "component", "enableColorScheme"];
-	const useUtilityClasses$K = ownerState => {
+	const _excluded$X = ["className", "component", "enableColorScheme"];
+	const useUtilityClasses$L = ownerState => {
 	  const {
 	    classes
 	  } = ownerState;
@@ -12359,11 +12359,11 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      className,
 	      component = 'div'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$W);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$X);
 	  const ownerState = _extends$2({}, props, {
 	    component
 	  });
-	  const classes = useUtilityClasses$K(ownerState);
+	  const classes = useUtilityClasses$L(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ScopedCssBaselineRoot, _extends$2({
 	    as: component,
 	    className: clsx(classes.root, className),
@@ -43335,12 +43335,12 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  return theme[THEME_ID] || theme;
 	}
 
-	const _excluded$V = ["theme"];
+	const _excluded$W = ["theme"];
 	function ThemeProvider(_ref) {
 	  let {
 	      theme: themeInput
 	    } = _ref,
-	    props = _objectWithoutPropertiesLoose$1(_ref, _excluded$V);
+	    props = _objectWithoutPropertiesLoose$1(_ref, _excluded$W);
 	  const scopedTheme = themeInput[THEME_ID];
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ThemeProvider$1, _extends$2({}, props, {
 	    themeId: scopedTheme ? THEME_ID : undefined,
@@ -43601,7 +43601,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  };
 	}
 
-	const _excluded$U = ["elementType", "externalSlotProps", "ownerState", "skipResolvingSlotProps"];
+	const _excluded$V = ["elementType", "externalSlotProps", "ownerState", "skipResolvingSlotProps"];
 	/**
 	 * @ignore - do not document.
 	 * Builds the props to be passed into the slot of an unstyled component.
@@ -43618,7 +43618,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      ownerState,
 	      skipResolvingSlotProps = false
 	    } = parameters,
-	    rest = _objectWithoutPropertiesLoose$1(parameters, _excluded$U);
+	    rest = _objectWithoutPropertiesLoose$1(parameters, _excluded$V);
 	  const resolvedComponentsProps = skipResolvingSlotProps ? {} : resolveComponentProps(externalSlotProps, ownerState);
 	  const {
 	    props: mergedProps,
@@ -44745,7 +44745,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  };
 	}
 
-	const _excluded$T = ["onChange", "maxRows", "minRows", "style", "value"];
+	const _excluded$U = ["onChange", "maxRows", "minRows", "style", "value"];
 	function getStyleValue(value) {
 	  return parseInt(value, 10) || 0;
 	}
@@ -44787,7 +44787,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      style,
 	      value
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$T);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$U);
 	  const {
 	    current: isControlled
 	  } = reactExports.useRef(value != null);
@@ -45010,10 +45010,10 @@ Please use another name.` : formatMuiErrorMessage(18));
 	'anchorOriginTopLeftCircular', 'anchorOriginTopLeftRectangular', 'anchorOriginTopRightCircular', 'anchorOriginTopRightRectangular', 'anchorOriginBottomLeftCircular', 'anchorOriginBottomLeftRectangular', 'anchorOriginBottomRightCircular', 'anchorOriginBottomRightRectangular']);
 	var badgeClasses$1 = badgeClasses;
 
-	const _excluded$S = ["anchorOrigin", "className", "classes", "component", "components", "componentsProps", "children", "overlap", "color", "invisible", "max", "badgeContent", "slots", "slotProps", "showZero", "variant"];
+	const _excluded$T = ["anchorOrigin", "className", "classes", "component", "components", "componentsProps", "children", "overlap", "color", "invisible", "max", "badgeContent", "slots", "slotProps", "showZero", "variant"];
 	const RADIUS_STANDARD = 10;
 	const RADIUS_DOT = 4;
-	const useUtilityClasses$J = ownerState => {
+	const useUtilityClasses$K = ownerState => {
 	  const {
 	    color,
 	    anchorOrigin,
@@ -45178,7 +45178,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      showZero = false,
 	      variant: variantProp = 'standard'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$S);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$T);
 	  const {
 	    badgeContent,
 	    invisible: invisibleFromHook,
@@ -45216,7 +45216,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    overlap,
 	    variant
 	  });
-	  const classes = useUtilityClasses$J(ownerState);
+	  const classes = useUtilityClasses$K(ownerState);
 
 	  // support both `slots` and `components` for backward compatibility
 	  const RootSlot = (_ref = (_slots$root = slots == null ? void 0 : slots.root) != null ? _slots$root : components.Root) != null ? _ref : BadgeRoot;
@@ -45369,8 +45369,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiTypography', ['root', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2', 'inherit', 'button', 'caption', 'overline', 'alignLeft', 'alignRight', 'alignCenter', 'alignJustify', 'noWrap', 'gutterBottom', 'paragraph']);
 
-	const _excluded$R = ["align", "className", "component", "gutterBottom", "noWrap", "paragraph", "variant", "variantMapping"];
-	const useUtilityClasses$I = ownerState => {
+	const _excluded$S = ["align", "className", "component", "gutterBottom", "noWrap", "paragraph", "variant", "variantMapping"];
+	const useUtilityClasses$J = ownerState => {
 	  const {
 	    align,
 	    gutterBottom,
@@ -45456,7 +45456,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      variant = 'body1',
 	      variantMapping = defaultVariantMapping
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$R);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$S);
 	  const ownerState = _extends$2({}, props, {
 	    align,
 	    color,
@@ -45469,7 +45469,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    variantMapping
 	  });
 	  const Component = component || (paragraph ? 'p' : variantMapping[variant] || defaultVariantMapping[variant]) || 'span';
-	  const classes = useUtilityClasses$I(ownerState);
+	  const classes = useUtilityClasses$J(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(TypographyRoot, _extends$2({
 	    as: Component,
 	    ref: ref,
@@ -45584,8 +45584,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	};
 	var getTextDecoration$1 = getTextDecoration;
 
-	const _excluded$Q = ["className", "color", "component", "onBlur", "onFocus", "TypographyClasses", "underline", "variant", "sx"];
-	const useUtilityClasses$H = ownerState => {
+	const _excluded$R = ["className", "color", "component", "onBlur", "onFocus", "TypographyClasses", "underline", "variant", "sx"];
+	const useUtilityClasses$I = ownerState => {
 	  const {
 	    classes,
 	    component,
@@ -45673,7 +45673,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      variant = 'inherit',
 	      sx
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$Q);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$R);
 	  const {
 	    isFocusVisibleRef,
 	    onBlur: handleBlurVisible,
@@ -45707,7 +45707,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    underline,
 	    variant
 	  });
-	  const classes = useUtilityClasses$H(ownerState);
+	  const classes = useUtilityClasses$I(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(LinkRoot, _extends$2({
 	    color: color,
 	    className: clsx(classes.root, className),
@@ -45793,8 +45793,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiList', ['root', 'padding', 'dense', 'subheader']);
 
-	const _excluded$P = ["children", "className", "component", "dense", "disablePadding", "subheader"];
-	const useUtilityClasses$G = ownerState => {
+	const _excluded$Q = ["children", "className", "component", "dense", "disablePadding", "subheader"];
+	const useUtilityClasses$H = ownerState => {
 	  const {
 	    classes,
 	    disablePadding,
@@ -45841,7 +45841,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      disablePadding = false,
 	      subheader
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$P);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$Q);
 	  const context = reactExports.useMemo(() => ({
 	    dense
 	  }), [dense]);
@@ -45850,7 +45850,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    dense,
 	    disablePadding
 	  });
-	  const classes = useUtilityClasses$G(ownerState);
+	  const classes = useUtilityClasses$H(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ListContext$1.Provider, {
 	    value: context,
 	    children: /*#__PURE__*/jsxRuntimeExports.jsxs(ListRoot, _extends$2({
@@ -46977,7 +46977,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const touchRippleClasses = generateUtilityClasses('MuiTouchRipple', ['root', 'ripple', 'rippleVisible', 'ripplePulsate', 'child', 'childLeaving', 'childPulsate']);
 	var touchRippleClasses$1 = touchRippleClasses;
 
-	const _excluded$O = ["center", "classes", "className"];
+	const _excluded$P = ["center", "classes", "className"];
 	let _ = t => t,
 	  _t,
 	  _t2,
@@ -47106,7 +47106,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      classes = {},
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$O);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$P);
 	  const [ripples, setRipples] = reactExports.useState([]);
 	  const nextKey = reactExports.useRef(0);
 	  const rippleCallback = reactExports.useRef(null);
@@ -47309,8 +47309,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const buttonBaseClasses = generateUtilityClasses('MuiButtonBase', ['root', 'disabled', 'focusVisible']);
 	var buttonBaseClasses$1 = buttonBaseClasses;
 
-	const _excluded$N = ["action", "centerRipple", "children", "className", "component", "disabled", "disableRipple", "disableTouchRipple", "focusRipple", "focusVisibleClassName", "LinkComponent", "onBlur", "onClick", "onContextMenu", "onDragLeave", "onFocus", "onFocusVisible", "onKeyDown", "onKeyUp", "onMouseDown", "onMouseLeave", "onMouseUp", "onTouchEnd", "onTouchMove", "onTouchStart", "tabIndex", "TouchRippleProps", "touchRippleRef", "type"];
-	const useUtilityClasses$F = ownerState => {
+	const _excluded$O = ["action", "centerRipple", "children", "className", "component", "disabled", "disableRipple", "disableTouchRipple", "focusRipple", "focusVisibleClassName", "LinkComponent", "onBlur", "onClick", "onContextMenu", "onDragLeave", "onFocus", "onFocusVisible", "onKeyDown", "onKeyUp", "onMouseDown", "onMouseLeave", "onMouseUp", "onTouchEnd", "onTouchMove", "onTouchStart", "tabIndex", "TouchRippleProps", "touchRippleRef", "type"];
+	const useUtilityClasses$G = ownerState => {
 	  const {
 	    disabled,
 	    focusVisible,
@@ -47411,7 +47411,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      touchRippleRef,
 	      type
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$N);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$O);
 	  const buttonRef = reactExports.useRef(null);
 	  const rippleRef = reactExports.useRef(null);
 	  const handleRippleRef = useForkRef(rippleRef, touchRippleRef);
@@ -47578,7 +47578,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    tabIndex,
 	    focusVisible
 	  });
-	  const classes = useUtilityClasses$F(ownerState);
+	  const classes = useUtilityClasses$G(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsxs(ButtonBaseRoot, _extends$2({
 	    as: ComponentProp,
 	    className: clsx(classes.root, className),
@@ -47781,14 +47781,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const listItemButtonClasses = generateUtilityClasses('MuiListItemButton', ['root', 'focusVisible', 'dense', 'alignItemsFlexStart', 'disabled', 'divider', 'gutters', 'selected']);
 	var listItemButtonClasses$1 = listItemButtonClasses;
 
-	const _excluded$M = ["alignItems", "autoFocus", "component", "children", "dense", "disableGutters", "divider", "focusVisibleClassName", "selected", "className"];
+	const _excluded$N = ["alignItems", "autoFocus", "component", "children", "dense", "disableGutters", "divider", "focusVisibleClassName", "selected", "className"];
 	const overridesResolver$3 = (props, styles) => {
 	  const {
 	    ownerState
 	  } = props;
 	  return [styles.root, ownerState.dense && styles.dense, ownerState.alignItems === 'flex-start' && styles.alignItemsFlexStart, ownerState.divider && styles.divider, !ownerState.disableGutters && styles.gutters];
 	};
-	const useUtilityClasses$E = ownerState => {
+	const useUtilityClasses$F = ownerState => {
 	  const {
 	    alignItems,
 	    classes,
@@ -47883,7 +47883,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      selected = false,
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$M);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$N);
 	  const context = reactExports.useContext(ListContext$1);
 	  const childContext = reactExports.useMemo(() => ({
 	    dense: dense || context.dense || false,
@@ -47907,7 +47907,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    divider,
 	    selected
 	  });
-	  const classes = useUtilityClasses$E(ownerState);
+	  const classes = useUtilityClasses$F(ownerState);
 	  const handleRef = useForkRef(listItemRef, ref);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ListContext$1.Provider, {
 	    value: childContext,
@@ -48011,8 +48011,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiListItemSecondaryAction', ['root', 'disableGutters']);
 
-	const _excluded$L = ["className"];
-	const useUtilityClasses$D = ownerState => {
+	const _excluded$M = ["className"];
+	const useUtilityClasses$E = ownerState => {
 	  const {
 	    disableGutters,
 	    classes
@@ -48053,12 +48053,12 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  const {
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$L);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$M);
 	  const context = reactExports.useContext(ListContext$1);
 	  const ownerState = _extends$2({}, props, {
 	    disableGutters: context.disableGutters
 	  });
-	  const classes = useUtilityClasses$D(ownerState);
+	  const classes = useUtilityClasses$E(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ListItemSecondaryActionRoot, _extends$2({
 	    className: clsx(classes.root, className),
 	    ownerState: ownerState,
@@ -48090,7 +48090,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	ListItemSecondaryAction.muiName = 'ListItemSecondaryAction';
 	var ListItemSecondaryAction$1 = ListItemSecondaryAction;
 
-	const _excluded$K = ["className"],
+	const _excluded$L = ["className"],
 	  _excluded2$4 = ["alignItems", "autoFocus", "button", "children", "className", "component", "components", "componentsProps", "ContainerComponent", "ContainerProps", "dense", "disabled", "disableGutters", "disablePadding", "divider", "focusVisibleClassName", "secondaryAction", "selected", "slotProps", "slots"];
 	const overridesResolver$2 = (props, styles) => {
 	  const {
@@ -48098,7 +48098,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  } = props;
 	  return [styles.root, ownerState.dense && styles.dense, ownerState.alignItems === 'flex-start' && styles.alignItemsFlexStart, ownerState.divider && styles.divider, !ownerState.disableGutters && styles.gutters, !ownerState.disablePadding && styles.padding, ownerState.button && styles.button, ownerState.hasSecondaryAction && styles.secondaryAction];
 	};
-	const useUtilityClasses$C = ownerState => {
+	const useUtilityClasses$D = ownerState => {
 	  const {
 	    alignItems,
 	    button,
@@ -48232,7 +48232,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      slotProps = {},
 	      slots = {}
 	    } = props,
-	    ContainerProps = _objectWithoutPropertiesLoose$1(props.ContainerProps, _excluded$K),
+	    ContainerProps = _objectWithoutPropertiesLoose$1(props.ContainerProps, _excluded$L),
 	    other = _objectWithoutPropertiesLoose$1(props, _excluded2$4);
 	  const context = reactExports.useContext(ListContext$1);
 	  const childContext = reactExports.useMemo(() => ({
@@ -48266,7 +48266,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    hasSecondaryAction,
 	    selected
 	  });
-	  const classes = useUtilityClasses$C(ownerState);
+	  const classes = useUtilityClasses$D(ownerState);
 	  const handleRef = useForkRef(listItemRef, ref);
 	  const Root = slots.root || components.Root || ListItemRoot;
 	  const rootProps = slotProps.root || componentsProps.root || {};
@@ -48495,8 +48495,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const listItemTextClasses = generateUtilityClasses('MuiListItemText', ['root', 'multiline', 'dense', 'inset', 'primary', 'secondary']);
 	var listItemTextClasses$1 = listItemTextClasses;
 
-	const _excluded$J = ["children", "className", "disableTypography", "inset", "primary", "primaryTypographyProps", "secondary", "secondaryTypographyProps"];
-	const useUtilityClasses$B = ownerState => {
+	const _excluded$K = ["children", "className", "disableTypography", "inset", "primary", "primaryTypographyProps", "secondary", "secondaryTypographyProps"];
+	const useUtilityClasses$C = ownerState => {
 	  const {
 	    classes,
 	    inset,
@@ -48552,7 +48552,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      secondary: secondaryProp,
 	      secondaryTypographyProps
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$J);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$K);
 	  const {
 	    dense
 	  } = reactExports.useContext(ListContext$1);
@@ -48565,7 +48565,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    secondary: !!secondary,
 	    dense
 	  });
-	  const classes = useUtilityClasses$B(ownerState);
+	  const classes = useUtilityClasses$C(ownerState);
 	  if (primary != null && primary.type !== Typography$1 && !disableTypography) {
 	    primary = /*#__PURE__*/jsxRuntimeExports.jsx(Typography$1, _extends$2({
 	      variant: dense ? 'body2' : 'body1',
@@ -48655,8 +48655,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiListItemAvatar', ['root', 'alignItemsFlexStart']);
 
-	const _excluded$I = ["className"];
-	const useUtilityClasses$A = ownerState => {
+	const _excluded$J = ["className"];
+	const useUtilityClasses$B = ownerState => {
 	  const {
 	    alignItems,
 	    classes
@@ -48695,12 +48695,12 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  const {
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$I);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$J);
 	  const context = reactExports.useContext(ListContext$1);
 	  const ownerState = _extends$2({}, props, {
 	    alignItems: context.alignItems
 	  });
-	  const classes = useUtilityClasses$A(ownerState);
+	  const classes = useUtilityClasses$B(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ListItemAvatarRoot, _extends$2({
 	    className: clsx(classes.root, className),
 	    ownerState: ownerState,
@@ -48736,7 +48736,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiPagination', ['root', 'ul', 'outlined', 'text']);
 
-	const _excluded$H = ["boundaryCount", "componentName", "count", "defaultPage", "disabled", "hideNextButton", "hidePrevButton", "onChange", "page", "showFirstButton", "showLastButton", "siblingCount"];
+	const _excluded$I = ["boundaryCount", "componentName", "count", "defaultPage", "disabled", "hideNextButton", "hidePrevButton", "onChange", "page", "showFirstButton", "showLastButton", "siblingCount"];
 	function usePagination(props = {}) {
 	  // keep default values in sync with @default tags in Pagination.propTypes
 	  const {
@@ -48753,7 +48753,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      showLastButton = false,
 	      siblingCount = 1
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$H);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$I);
 	  const [page, setPageState] = useControlled({
 	    controlled: pageProp,
 	    default: defaultPage,
@@ -48858,8 +48858,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiSvgIcon', ['root', 'colorPrimary', 'colorSecondary', 'colorAction', 'colorError', 'colorDisabled', 'fontSizeInherit', 'fontSizeSmall', 'fontSizeMedium', 'fontSizeLarge']);
 
-	const _excluded$G = ["children", "className", "color", "component", "fontSize", "htmlColor", "inheritViewBox", "titleAccess", "viewBox"];
-	const useUtilityClasses$z = ownerState => {
+	const _excluded$H = ["children", "className", "color", "component", "fontSize", "htmlColor", "inheritViewBox", "titleAccess", "viewBox"];
+	const useUtilityClasses$A = ownerState => {
 	  const {
 	    color,
 	    fontSize,
@@ -48926,7 +48926,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      titleAccess,
 	      viewBox = '0 0 24 24'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$G);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$H);
 	  const hasSvgAsChild = /*#__PURE__*/reactExports.isValidElement(children) && children.type === 'svg';
 	  const ownerState = _extends$2({}, props, {
 	    color,
@@ -48941,7 +48941,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  if (!inheritViewBox) {
 	    more.viewBox = viewBox;
 	  }
-	  const classes = useUtilityClasses$z(ownerState);
+	  const classes = useUtilityClasses$A(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsxs(SvgIconRoot, _extends$2({
 	    as: component,
 	    className: clsx(classes.root, className),
@@ -49066,14 +49066,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  d: "M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
 	}), 'NavigateNext');
 
-	const _excluded$F = ["className", "color", "component", "components", "disabled", "page", "selected", "shape", "size", "slots", "type", "variant"];
+	const _excluded$G = ["className", "color", "component", "components", "disabled", "page", "selected", "shape", "size", "slots", "type", "variant"];
 	const overridesResolver$1 = (props, styles) => {
 	  const {
 	    ownerState
 	  } = props;
 	  return [styles.root, styles[ownerState.variant], styles[`size${capitalize(ownerState.size)}`], ownerState.variant === 'text' && styles[`text${capitalize(ownerState.color)}`], ownerState.variant === 'outlined' && styles[`outlined${capitalize(ownerState.color)}`], ownerState.shape === 'rounded' && styles.rounded, ownerState.type === 'page' && styles.page, (ownerState.type === 'start-ellipsis' || ownerState.type === 'end-ellipsis') && styles.ellipsis, (ownerState.type === 'previous' || ownerState.type === 'next') && styles.previousNext, (ownerState.type === 'first' || ownerState.type === 'last') && styles.firstLast];
 	};
-	const useUtilityClasses$y = ownerState => {
+	const useUtilityClasses$z = ownerState => {
 	  const {
 	    classes,
 	    color,
@@ -49271,7 +49271,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      type = 'page',
 	      variant = 'text'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$F);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$G);
 	  const ownerState = _extends$2({}, props, {
 	    color,
 	    disabled,
@@ -49282,7 +49282,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    variant
 	  });
 	  const theme = useTheme();
-	  const classes = useUtilityClasses$y(ownerState);
+	  const classes = useUtilityClasses$z(ownerState);
 	  const normalizedIcons = theme.direction === 'rtl' ? {
 	    previous: slots.next || components.next || NavigateNextIcon,
 	    next: slots.previous || components.previous || NavigateBeforeIcon,
@@ -49411,8 +49411,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	} : void 0;
 	var PaginationItem$1 = PaginationItem;
 
-	const _excluded$E = ["boundaryCount", "className", "color", "count", "defaultPage", "disabled", "getItemAriaLabel", "hideNextButton", "hidePrevButton", "onChange", "page", "renderItem", "shape", "showFirstButton", "showLastButton", "siblingCount", "size", "variant"];
-	const useUtilityClasses$x = ownerState => {
+	const _excluded$F = ["boundaryCount", "className", "color", "count", "defaultPage", "disabled", "getItemAriaLabel", "hideNextButton", "hidePrevButton", "onChange", "page", "renderItem", "shape", "showFirstButton", "showLastButton", "siblingCount", "size", "variant"];
+	const useUtilityClasses$y = ownerState => {
 	  const {
 	    classes,
 	    variant
@@ -49474,7 +49474,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      size = 'medium',
 	      variant = 'text'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$E);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$F);
 	  const {
 	    items
 	  } = usePagination(_extends$2({}, props, {
@@ -49497,7 +49497,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    size,
 	    variant
 	  });
-	  const classes = useUtilityClasses$x(ownerState);
+	  const classes = useUtilityClasses$y(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(PaginationRoot, _extends$2({
 	    "aria-label": "pagination navigation",
 	    className: clsx(classes.root, className),
@@ -49647,8 +49647,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiAvatar', ['root', 'colorDefault', 'circular', 'rounded', 'square', 'img', 'fallback']);
 
-	const _excluded$D = ["alt", "children", "className", "component", "imgProps", "sizes", "src", "srcSet", "variant"];
-	const useUtilityClasses$w = ownerState => {
+	const _excluded$E = ["alt", "children", "className", "component", "imgProps", "sizes", "src", "srcSet", "variant"];
+	const useUtilityClasses$x = ownerState => {
 	  const {
 	    classes,
 	    variant,
@@ -49775,7 +49775,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      srcSet,
 	      variant = 'circular'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$D);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$E);
 	  let children = null;
 
 	  // Use a hook instead of onError on the img element to support server-side rendering.
@@ -49790,7 +49790,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    component,
 	    variant
 	  });
-	  const classes = useUtilityClasses$w(ownerState);
+	  const classes = useUtilityClasses$x(ownerState);
 	  if (hasImgNotFailing) {
 	    children = /*#__PURE__*/jsxRuntimeExports.jsx(AvatarImg, _extends$2({
 	      alt: alt,
@@ -49883,8 +49883,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const iconButtonClasses = generateUtilityClasses('MuiIconButton', ['root', 'disabled', 'colorInherit', 'colorPrimary', 'colorSecondary', 'colorError', 'colorInfo', 'colorSuccess', 'colorWarning', 'edgeStart', 'edgeEnd', 'sizeSmall', 'sizeMedium', 'sizeLarge']);
 	var iconButtonClasses$1 = iconButtonClasses;
 
-	const _excluded$C = ["edge", "children", "className", "color", "disabled", "disableFocusRipple", "size"];
-	const useUtilityClasses$v = ownerState => {
+	const _excluded$D = ["edge", "children", "className", "color", "disabled", "disableFocusRipple", "size"];
+	const useUtilityClasses$w = ownerState => {
 	  const {
 	    classes,
 	    disabled,
@@ -49984,7 +49984,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      disableFocusRipple = false,
 	      size = 'medium'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$C);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$D);
 	  const ownerState = _extends$2({}, props, {
 	    edge,
 	    color,
@@ -49992,7 +49992,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    disableFocusRipple,
 	    size
 	  });
-	  const classes = useUtilityClasses$v(ownerState);
+	  const classes = useUtilityClasses$w(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(IconButtonRoot, _extends$2({
 	    className: clsx(classes.root, className),
 	    centerRipple: true,
@@ -50073,7 +50073,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	} : void 0;
 	var IconButton$1 = IconButton;
 
-	const _excluded$B = ["actions", "autoFocus", "autoFocusItem", "children", "className", "disabledItemsFocusable", "disableListWrap", "onKeyDown", "variant"];
+	const _excluded$C = ["actions", "autoFocus", "autoFocusItem", "children", "className", "disabledItemsFocusable", "disableListWrap", "onKeyDown", "variant"];
 	function nextItem(list, item, disableListWrap) {
 	  if (list === item) {
 	    return list.firstChild;
@@ -50155,7 +50155,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      onKeyDown,
 	      variant = 'selectedMenu'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$B);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$C);
 	  const listRef = reactExports.useRef(null);
 	  const textCriteriaRef = reactExports.useRef({
 	    keys: [],
@@ -50358,7 +50358,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  };
 	}
 
-	const _excluded$A = ["addEndListener", "appear", "children", "easing", "in", "onEnter", "onEntered", "onEntering", "onExit", "onExited", "onExiting", "style", "timeout", "TransitionComponent"];
+	const _excluded$B = ["addEndListener", "appear", "children", "easing", "in", "onEnter", "onEntered", "onEntering", "onExit", "onExited", "onExiting", "style", "timeout", "TransitionComponent"];
 	function getScale(value) {
 	  return `scale(${value}, ${value ** 2})`;
 	}
@@ -50402,7 +50402,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      // eslint-disable-next-line react/prop-types
 	      TransitionComponent = Transition$1
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$A);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$B);
 	  const timer = reactExports.useRef();
 	  const autoTimeout = reactExports.useRef();
 	  const theme = useTheme();
@@ -50606,7 +50606,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	Grow.muiSupportAuto = true;
 	var Grow$1 = Grow;
 
-	const _excluded$z = ["addEndListener", "appear", "children", "easing", "in", "onEnter", "onEntered", "onEntering", "onExit", "onExited", "onExiting", "style", "timeout", "TransitionComponent"];
+	const _excluded$A = ["addEndListener", "appear", "children", "easing", "in", "onEnter", "onEntered", "onEntering", "onExit", "onExited", "onExiting", "style", "timeout", "TransitionComponent"];
 	const styles = {
 	  entering: {
 	    opacity: 1
@@ -50643,7 +50643,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      // eslint-disable-next-line react/prop-types
 	      TransitionComponent = Transition$1
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$z);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$A);
 	  const nodeRef = reactExports.useRef(null);
 	  const handleRef = useForkRef(nodeRef, children.ref, ref);
 	  const normalizedTransitionCallback = callback => maybeIsAppearing => {
@@ -50804,8 +50804,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiBackdrop', ['root', 'invisible']);
 
-	const _excluded$y = ["children", "className", "component", "components", "componentsProps", "invisible", "open", "slotProps", "slots", "TransitionComponent", "transitionDuration"];
-	const useUtilityClasses$u = ownerState => {
+	const _excluded$z = ["children", "className", "component", "components", "componentsProps", "invisible", "open", "slotProps", "slots", "TransitionComponent", "transitionDuration"];
+	const useUtilityClasses$v = ownerState => {
 	  const {
 	    classes,
 	    invisible
@@ -50859,12 +50859,12 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      TransitionComponent = Fade$1,
 	      transitionDuration
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$y);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$z);
 	  const ownerState = _extends$2({}, props, {
 	    component,
 	    invisible
 	  });
-	  const classes = useUtilityClasses$u(ownerState);
+	  const classes = useUtilityClasses$v(ownerState);
 	  const rootSlotProps = (_slotProps$root = slotProps.root) != null ? _slotProps$root : componentsProps.root;
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(TransitionComponent, _extends$2({
 	    in: open,
@@ -50985,8 +50985,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiModal', ['root', 'hidden', 'backdrop']);
 
-	const _excluded$x = ["BackdropComponent", "BackdropProps", "classes", "className", "closeAfterTransition", "children", "container", "component", "components", "componentsProps", "disableAutoFocus", "disableEnforceFocus", "disableEscapeKeyDown", "disablePortal", "disableRestoreFocus", "disableScrollLock", "hideBackdrop", "keepMounted", "onBackdropClick", "onClose", "onTransitionEnter", "onTransitionExited", "open", "slotProps", "slots", "theme"];
-	const useUtilityClasses$t = ownerState => {
+	const _excluded$y = ["BackdropComponent", "BackdropProps", "classes", "className", "closeAfterTransition", "children", "container", "component", "components", "componentsProps", "disableAutoFocus", "disableEnforceFocus", "disableEscapeKeyDown", "disablePortal", "disableRestoreFocus", "disableScrollLock", "hideBackdrop", "keepMounted", "onBackdropClick", "onClose", "onTransitionEnter", "onTransitionExited", "open", "slotProps", "slots", "theme"];
+	const useUtilityClasses$u = ownerState => {
 	  const {
 	    open,
 	    exited,
@@ -51073,7 +51073,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      slots
 	      // eslint-disable-next-line react/prop-types
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$x);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$y);
 	  const propsWithDefaults = _extends$2({}, props, {
 	    closeAfterTransition,
 	    disableAutoFocus,
@@ -51099,7 +51099,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  const ownerState = _extends$2({}, propsWithDefaults, {
 	    exited
 	  });
-	  const classes = useUtilityClasses$t(ownerState);
+	  const classes = useUtilityClasses$u(ownerState);
 	  const childProps = {};
 	  if (children.props.tabIndex === undefined) {
 	    childProps.tabIndex = '-1';
@@ -51353,8 +51353,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiPaper', ['root', 'rounded', 'outlined', 'elevation', 'elevation0', 'elevation1', 'elevation2', 'elevation3', 'elevation4', 'elevation5', 'elevation6', 'elevation7', 'elevation8', 'elevation9', 'elevation10', 'elevation11', 'elevation12', 'elevation13', 'elevation14', 'elevation15', 'elevation16', 'elevation17', 'elevation18', 'elevation19', 'elevation20', 'elevation21', 'elevation22', 'elevation23', 'elevation24']);
 
-	const _excluded$w = ["className", "component", "elevation", "square", "variant"];
-	const useUtilityClasses$s = ownerState => {
+	const _excluded$x = ["className", "component", "elevation", "square", "variant"];
+	const useUtilityClasses$t = ownerState => {
 	  const {
 	    square,
 	    elevation,
@@ -51408,14 +51408,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      square = false,
 	      variant = 'elevation'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$w);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$x);
 	  const ownerState = _extends$2({}, props, {
 	    component,
 	    elevation,
 	    square,
 	    variant
 	  });
-	  const classes = useUtilityClasses$s(ownerState);
+	  const classes = useUtilityClasses$t(ownerState);
 	  if (process.env.NODE_ENV !== 'production') {
 	    // eslint-disable-next-line react-hooks/rules-of-hooks
 	    const theme = useTheme();
@@ -51489,7 +51489,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiPopover', ['root', 'paper']);
 
-	const _excluded$v = ["onEntering"],
+	const _excluded$w = ["onEntering"],
 	  _excluded2$3 = ["action", "anchorEl", "anchorOrigin", "anchorPosition", "anchorReference", "children", "className", "container", "elevation", "marginThreshold", "open", "PaperProps", "slots", "slotProps", "transformOrigin", "TransitionComponent", "transitionDuration", "TransitionProps", "disableScrollLock"],
 	  _excluded3 = ["slotProps"];
 	function getOffsetTop(rect, vertical) {
@@ -51520,7 +51520,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	function resolveAnchorEl(anchorEl) {
 	  return typeof anchorEl === 'function' ? anchorEl() : anchorEl;
 	}
-	const useUtilityClasses$r = ownerState => {
+	const useUtilityClasses$s = ownerState => {
 	  const {
 	    classes
 	  } = ownerState;
@@ -51587,7 +51587,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      } = {},
 	      disableScrollLock = false
 	    } = props,
-	    TransitionProps = _objectWithoutPropertiesLoose$1(props.TransitionProps, _excluded$v),
+	    TransitionProps = _objectWithoutPropertiesLoose$1(props.TransitionProps, _excluded$w),
 	    other = _objectWithoutPropertiesLoose$1(props, _excluded2$3);
 	  const externalPaperSlotProps = (_slotProps$paper = slotProps == null ? void 0 : slotProps.paper) != null ? _slotProps$paper : PaperPropsProp;
 	  const paperRef = reactExports.useRef();
@@ -51603,7 +51603,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    transitionDuration: transitionDurationProp,
 	    TransitionProps
 	  });
-	  const classes = useUtilityClasses$r(ownerState);
+	  const classes = useUtilityClasses$s(ownerState);
 
 	  // Returns the top/left offset of the position
 	  // to attach to on the anchor element (or body if none is provided)
@@ -52006,7 +52006,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiMenu', ['root', 'paper', 'list']);
 
-	const _excluded$u = ["onEntering"],
+	const _excluded$v = ["onEntering"],
 	  _excluded2$2 = ["autoFocus", "children", "className", "disableAutoFocusItem", "MenuListProps", "onClose", "open", "PaperProps", "PopoverClasses", "transitionDuration", "TransitionProps", "variant", "slots", "slotProps"];
 	const RTL_ORIGIN = {
 	  vertical: 'top',
@@ -52016,7 +52016,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  vertical: 'top',
 	  horizontal: 'left'
 	};
-	const useUtilityClasses$q = ownerState => {
+	const useUtilityClasses$r = ownerState => {
 	  const {
 	    classes
 	  } = ownerState;
@@ -52077,7 +52077,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      slots = {},
 	      slotProps = {}
 	    } = props,
-	    TransitionProps = _objectWithoutPropertiesLoose$1(props.TransitionProps, _excluded$u),
+	    TransitionProps = _objectWithoutPropertiesLoose$1(props.TransitionProps, _excluded$v),
 	    other = _objectWithoutPropertiesLoose$1(props, _excluded2$2);
 	  const theme = useTheme();
 	  const isRtl = theme.direction === 'rtl';
@@ -52091,7 +52091,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    TransitionProps,
 	    variant
 	  });
-	  const classes = useUtilityClasses$q(ownerState);
+	  const classes = useUtilityClasses$r(ownerState);
 	  const autoFocusItem = autoFocus && !disableAutoFocusItem && open;
 	  const menuListActionsRef = reactExports.useRef(null);
 	  const handleEntering = (element, isAppearing) => {
@@ -52301,8 +52301,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const dividerClasses = generateUtilityClasses('MuiDivider', ['root', 'absolute', 'fullWidth', 'inset', 'middle', 'flexItem', 'light', 'vertical', 'withChildren', 'withChildrenVertical', 'textAlignRight', 'textAlignLeft', 'wrapper', 'wrapperVertical']);
 	var dividerClasses$1 = dividerClasses;
 
-	const _excluded$t = ["absolute", "children", "className", "component", "flexItem", "light", "orientation", "role", "textAlign", "variant"];
-	const useUtilityClasses$p = ownerState => {
+	const _excluded$u = ["absolute", "children", "className", "component", "flexItem", "light", "orientation", "role", "textAlign", "variant"];
+	const useUtilityClasses$q = ownerState => {
 	  const {
 	    absolute,
 	    children,
@@ -52443,7 +52443,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      textAlign = 'center',
 	      variant = 'fullWidth'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$t);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$u);
 	  const ownerState = _extends$2({}, props, {
 	    absolute,
 	    component,
@@ -52454,7 +52454,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    textAlign,
 	    variant
 	  });
-	  const classes = useUtilityClasses$p(ownerState);
+	  const classes = useUtilityClasses$q(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(DividerRoot, _extends$2({
 	    as: component,
 	    className: clsx(classes.root, className),
@@ -52545,8 +52545,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const listItemIconClasses = generateUtilityClasses('MuiListItemIcon', ['root', 'alignItemsFlexStart']);
 	var listItemIconClasses$1 = listItemIconClasses;
 
-	const _excluded$s = ["className"];
-	const useUtilityClasses$o = ownerState => {
+	const _excluded$t = ["className"];
+	const useUtilityClasses$p = ownerState => {
 	  const {
 	    alignItems,
 	    classes
@@ -52588,12 +52588,12 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  const {
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$s);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$t);
 	  const context = reactExports.useContext(ListContext$1);
 	  const ownerState = _extends$2({}, props, {
 	    alignItems: context.alignItems
 	  });
-	  const classes = useUtilityClasses$o(ownerState);
+	  const classes = useUtilityClasses$p(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(ListItemIconRoot, _extends$2({
 	    className: clsx(classes.root, className),
 	    ownerState: ownerState,
@@ -52631,14 +52631,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const menuItemClasses = generateUtilityClasses('MuiMenuItem', ['root', 'focusVisible', 'dense', 'disabled', 'divider', 'gutters', 'selected']);
 	var menuItemClasses$1 = menuItemClasses;
 
-	const _excluded$r = ["autoFocus", "component", "dense", "divider", "disableGutters", "focusVisibleClassName", "role", "tabIndex", "className"];
+	const _excluded$s = ["autoFocus", "component", "dense", "divider", "disableGutters", "focusVisibleClassName", "role", "tabIndex", "className"];
 	const overridesResolver = (props, styles) => {
 	  const {
 	    ownerState
 	  } = props;
 	  return [styles.root, ownerState.dense && styles.dense, ownerState.divider && styles.divider, !ownerState.disableGutters && styles.gutters];
 	};
-	const useUtilityClasses$n = ownerState => {
+	const useUtilityClasses$o = ownerState => {
 	  const {
 	    disabled,
 	    dense,
@@ -52753,7 +52753,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      tabIndex: tabIndexProp,
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$r);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$s);
 	  const context = reactExports.useContext(ListContext$1);
 	  const childContext = reactExports.useMemo(() => ({
 	    dense: dense || context.dense || false,
@@ -52774,7 +52774,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    divider,
 	    disableGutters
 	  });
-	  const classes = useUtilityClasses$n(props);
+	  const classes = useUtilityClasses$o(props);
 	  const handleRef = useForkRef(menuItemRef, ref);
 	  let tabIndex;
 	  if (!props.disabled) {
@@ -57682,218 +57682,108 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  }, COURSEFLOW_APP.strings.no_notifications_yet))));
 	};
 
-	function getAlertUtilityClass(slot) {
-	  return generateUtilityClass('MuiAlert', slot);
+	function getFormGroupUtilityClass(slot) {
+	  return generateUtilityClass('MuiFormGroup', slot);
 	}
-	const alertClasses = generateUtilityClasses('MuiAlert', ['root', 'action', 'icon', 'message', 'filled', 'filledSuccess', 'filledInfo', 'filledWarning', 'filledError', 'outlined', 'outlinedSuccess', 'outlinedInfo', 'outlinedWarning', 'outlinedError', 'standard', 'standardSuccess', 'standardInfo', 'standardWarning', 'standardError']);
-	var alertClasses$1 = alertClasses;
+	generateUtilityClasses('MuiFormGroup', ['root', 'row', 'error']);
 
-	var SuccessOutlinedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
-	  d: "M20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4C12.76,4 13.5,4.11 14.2, 4.31L15.77,2.74C14.61,2.26 13.34,2 12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0, 0 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
-	}), 'SuccessOutlined');
+	/**
+	 * @ignore - internal component.
+	 */
+	const FormControlContext = /*#__PURE__*/reactExports.createContext(undefined);
+	if (process.env.NODE_ENV !== 'production') {
+	  FormControlContext.displayName = 'FormControlContext';
+	}
+	var FormControlContext$1 = FormControlContext;
 
-	var ReportProblemOutlinedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
-	  d: "M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-	}), 'ReportProblemOutlined');
+	function useFormControl() {
+	  return reactExports.useContext(FormControlContext$1);
+	}
 
-	var ErrorOutlineIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
-	  d: "M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-	}), 'ErrorOutline');
+	function formControlState({
+	  props,
+	  states,
+	  muiFormControl
+	}) {
+	  return states.reduce((acc, state) => {
+	    acc[state] = props[state];
+	    if (muiFormControl) {
+	      if (typeof props[state] === 'undefined') {
+	        acc[state] = muiFormControl[state];
+	      }
+	    }
+	    return acc;
+	  }, {});
+	}
 
-	var InfoOutlinedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
-	  d: "M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
-	}), 'InfoOutlined');
-
-	var CloseIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
-	  d: "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-	}), 'Close');
-
-	const _excluded$q = ["action", "children", "className", "closeText", "color", "components", "componentsProps", "icon", "iconMapping", "onClose", "role", "severity", "slotProps", "slots", "variant"];
-	const useUtilityClasses$m = ownerState => {
+	const _excluded$r = ["className", "row"];
+	const useUtilityClasses$n = ownerState => {
 	  const {
-	    variant,
-	    color,
-	    severity,
-	    classes
+	    classes,
+	    row,
+	    error
 	  } = ownerState;
 	  const slots = {
-	    root: ['root', `${variant}${capitalize(color || severity)}`, `${variant}`],
-	    icon: ['icon'],
-	    message: ['message'],
-	    action: ['action']
+	    root: ['root', row && 'row', error && 'error']
 	  };
-	  return composeClasses(slots, getAlertUtilityClass, classes);
+	  return composeClasses(slots, getFormGroupUtilityClass, classes);
 	};
-	const AlertRoot = styled$1(Paper$1, {
-	  name: 'MuiAlert',
+	const FormGroupRoot = styled$1('div', {
+	  name: 'MuiFormGroup',
 	  slot: 'Root',
 	  overridesResolver: (props, styles) => {
 	    const {
 	      ownerState
 	    } = props;
-	    return [styles.root, styles[ownerState.variant], styles[`${ownerState.variant}${capitalize(ownerState.color || ownerState.severity)}`]];
+	    return [styles.root, ownerState.row && styles.row];
 	  }
 	})(({
-	  theme,
 	  ownerState
-	}) => {
-	  const getColor = theme.palette.mode === 'light' ? darken : lighten;
-	  const getBackgroundColor = theme.palette.mode === 'light' ? lighten : darken;
-	  const color = ownerState.color || ownerState.severity;
-	  return _extends$2({}, theme.typography.body2, {
-	    backgroundColor: 'transparent',
-	    display: 'flex',
-	    padding: '6px 16px'
-	  }, color && ownerState.variant === 'standard' && {
-	    color: theme.vars ? theme.vars.palette.Alert[`${color}Color`] : getColor(theme.palette[color].light, 0.6),
-	    backgroundColor: theme.vars ? theme.vars.palette.Alert[`${color}StandardBg`] : getBackgroundColor(theme.palette[color].light, 0.9),
-	    [`& .${alertClasses$1.icon}`]: theme.vars ? {
-	      color: theme.vars.palette.Alert[`${color}IconColor`]
-	    } : {
-	      color: theme.palette[color].main
-	    }
-	  }, color && ownerState.variant === 'outlined' && {
-	    color: theme.vars ? theme.vars.palette.Alert[`${color}Color`] : getColor(theme.palette[color].light, 0.6),
-	    border: `1px solid ${(theme.vars || theme).palette[color].light}`,
-	    [`& .${alertClasses$1.icon}`]: theme.vars ? {
-	      color: theme.vars.palette.Alert[`${color}IconColor`]
-	    } : {
-	      color: theme.palette[color].main
-	    }
-	  }, color && ownerState.variant === 'filled' && _extends$2({
-	    fontWeight: theme.typography.fontWeightMedium
-	  }, theme.vars ? {
-	    color: theme.vars.palette.Alert[`${color}FilledColor`],
-	    backgroundColor: theme.vars.palette.Alert[`${color}FilledBg`]
-	  } : {
-	    backgroundColor: theme.palette.mode === 'dark' ? theme.palette[color].dark : theme.palette[color].main,
-	    color: theme.palette.getContrastText(theme.palette[color].main)
-	  }));
-	});
-	const AlertIcon = styled$1('div', {
-	  name: 'MuiAlert',
-	  slot: 'Icon',
-	  overridesResolver: (props, styles) => styles.icon
-	})({
-	  marginRight: 12,
-	  padding: '7px 0',
+	}) => _extends$2({
 	  display: 'flex',
-	  fontSize: 22,
-	  opacity: 0.9
-	});
-	const AlertMessage = styled$1('div', {
-	  name: 'MuiAlert',
-	  slot: 'Message',
-	  overridesResolver: (props, styles) => styles.message
-	})({
-	  padding: '8px 0',
-	  minWidth: 0,
-	  overflow: 'auto'
-	});
-	const AlertAction = styled$1('div', {
-	  name: 'MuiAlert',
-	  slot: 'Action',
-	  overridesResolver: (props, styles) => styles.action
-	})({
-	  display: 'flex',
-	  alignItems: 'flex-start',
-	  padding: '4px 0 0 16px',
-	  marginLeft: 'auto',
-	  marginRight: -8
-	});
-	const defaultIconMapping = {
-	  success: /*#__PURE__*/jsxRuntimeExports.jsx(SuccessOutlinedIcon, {
-	    fontSize: "inherit"
-	  }),
-	  warning: /*#__PURE__*/jsxRuntimeExports.jsx(ReportProblemOutlinedIcon, {
-	    fontSize: "inherit"
-	  }),
-	  error: /*#__PURE__*/jsxRuntimeExports.jsx(ErrorOutlineIcon, {
-	    fontSize: "inherit"
-	  }),
-	  info: /*#__PURE__*/jsxRuntimeExports.jsx(InfoOutlinedIcon, {
-	    fontSize: "inherit"
-	  })
-	};
-	const Alert = /*#__PURE__*/reactExports.forwardRef(function Alert(inProps, ref) {
-	  var _ref, _slots$closeButton, _ref2, _slots$closeIcon, _slotProps$closeButto, _slotProps$closeIcon;
+	  flexDirection: 'column',
+	  flexWrap: 'wrap'
+	}, ownerState.row && {
+	  flexDirection: 'row'
+	}));
+
+	/**
+	 * `FormGroup` wraps controls such as `Checkbox` and `Switch`.
+	 * It provides compact row layout.
+	 * For the `Radio`, you should be using the `RadioGroup` component instead of this one.
+	 */
+	const FormGroup = /*#__PURE__*/reactExports.forwardRef(function FormGroup(inProps, ref) {
 	  const props = useThemeProps({
 	    props: inProps,
-	    name: 'MuiAlert'
+	    name: 'MuiFormGroup'
 	  });
 	  const {
-	      action,
-	      children,
 	      className,
-	      closeText = 'Close',
-	      color,
-	      components = {},
-	      componentsProps = {},
-	      icon,
-	      iconMapping = defaultIconMapping,
-	      onClose,
-	      role = 'alert',
-	      severity = 'success',
-	      slotProps = {},
-	      slots = {},
-	      variant = 'standard'
+	      row = false
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$q);
-	  const ownerState = _extends$2({}, props, {
-	    color,
-	    severity,
-	    variant
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$r);
+	  const muiFormControl = useFormControl();
+	  const fcs = formControlState({
+	    props,
+	    muiFormControl,
+	    states: ['error']
 	  });
-	  const classes = useUtilityClasses$m(ownerState);
-	  const AlertCloseButton = (_ref = (_slots$closeButton = slots.closeButton) != null ? _slots$closeButton : components.CloseButton) != null ? _ref : IconButton$1;
-	  const AlertCloseIcon = (_ref2 = (_slots$closeIcon = slots.closeIcon) != null ? _slots$closeIcon : components.CloseIcon) != null ? _ref2 : CloseIcon;
-	  const closeButtonProps = (_slotProps$closeButto = slotProps.closeButton) != null ? _slotProps$closeButto : componentsProps.closeButton;
-	  const closeIconProps = (_slotProps$closeIcon = slotProps.closeIcon) != null ? _slotProps$closeIcon : componentsProps.closeIcon;
-	  return /*#__PURE__*/jsxRuntimeExports.jsxs(AlertRoot, _extends$2({
-	    role: role,
-	    elevation: 0,
-	    ownerState: ownerState,
+	  const ownerState = _extends$2({}, props, {
+	    row,
+	    error: fcs.error
+	  });
+	  const classes = useUtilityClasses$n(ownerState);
+	  return /*#__PURE__*/jsxRuntimeExports.jsx(FormGroupRoot, _extends$2({
 	    className: clsx(classes.root, className),
+	    ownerState: ownerState,
 	    ref: ref
-	  }, other, {
-	    children: [icon !== false ? /*#__PURE__*/jsxRuntimeExports.jsx(AlertIcon, {
-	      ownerState: ownerState,
-	      className: classes.icon,
-	      children: icon || iconMapping[severity] || defaultIconMapping[severity]
-	    }) : null, /*#__PURE__*/jsxRuntimeExports.jsx(AlertMessage, {
-	      ownerState: ownerState,
-	      className: classes.message,
-	      children: children
-	    }), action != null ? /*#__PURE__*/jsxRuntimeExports.jsx(AlertAction, {
-	      ownerState: ownerState,
-	      className: classes.action,
-	      children: action
-	    }) : null, action == null && onClose ? /*#__PURE__*/jsxRuntimeExports.jsx(AlertAction, {
-	      ownerState: ownerState,
-	      className: classes.action,
-	      children: /*#__PURE__*/jsxRuntimeExports.jsx(AlertCloseButton, _extends$2({
-	        size: "small",
-	        "aria-label": closeText,
-	        title: closeText,
-	        color: "inherit",
-	        onClick: onClose
-	      }, closeButtonProps, {
-	        children: /*#__PURE__*/jsxRuntimeExports.jsx(AlertCloseIcon, _extends$2({
-	          fontSize: "small"
-	        }, closeIconProps))
-	      }))
-	    }) : null]
-	  }));
+	  }, other));
 	});
-	process.env.NODE_ENV !== "production" ? Alert.propTypes /* remove-proptypes */ = {
+	process.env.NODE_ENV !== "production" ? FormGroup.propTypes /* remove-proptypes */ = {
 	  // ----------------------------- Warning --------------------------------
 	  // | These PropTypes are generated from the TypeScript type definitions |
 	  // |     To update them edit the d.ts file and run "yarn proptypes"     |
 	  // ----------------------------------------------------------------------
-	  /**
-	   * The action to display. It renders after the message, at the end of the alert.
-	   */
-	  action: PropTypes.node,
 	  /**
 	   * The content of the component.
 	   */
@@ -57907,111 +57797,16 @@ Please use another name.` : formatMuiErrorMessage(18));
 	   */
 	  className: PropTypes.string,
 	  /**
-	   * Override the default label for the *close popup* icon button.
-	   *
-	   * For localization purposes, you can use the provided [translations](/material-ui/guides/localization/).
-	   * @default 'Close'
+	   * Display group of elements in a compact row.
+	   * @default false
 	   */
-	  closeText: PropTypes.string,
-	  /**
-	   * The color of the component. Unless provided, the value is taken from the `severity` prop.
-	   * It supports both default and custom theme colors, which can be added as shown in the
-	   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
-	   */
-	  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([PropTypes.oneOf(['error', 'info', 'success', 'warning']), PropTypes.string]),
-	  /**
-	   * The components used for each slot inside.
-	   *
-	   * This prop is an alias for the `slots` prop.
-	   * It's recommended to use the `slots` prop instead.
-	   *
-	   * @default {}
-	   */
-	  components: PropTypes.shape({
-	    CloseButton: PropTypes.elementType,
-	    CloseIcon: PropTypes.elementType
-	  }),
-	  /**
-	   * The extra props for the slot components.
-	   * You can override the existing props or add new ones.
-	   *
-	   * This prop is an alias for the `slotProps` prop.
-	   * It's recommended to use the `slotProps` prop instead, as `componentsProps` will be deprecated in the future.
-	   *
-	   * @default {}
-	   */
-	  componentsProps: PropTypes.shape({
-	    closeButton: PropTypes.object,
-	    closeIcon: PropTypes.object
-	  }),
-	  /**
-	   * Override the icon displayed before the children.
-	   * Unless provided, the icon is mapped to the value of the `severity` prop.
-	   * Set to `false` to remove the `icon`.
-	   */
-	  icon: PropTypes.node,
-	  /**
-	   * The component maps the `severity` prop to a range of different icons,
-	   * for instance success to `<SuccessOutlined>`.
-	   * If you wish to change this mapping, you can provide your own.
-	   * Alternatively, you can use the `icon` prop to override the icon displayed.
-	   */
-	  iconMapping: PropTypes.shape({
-	    error: PropTypes.node,
-	    info: PropTypes.node,
-	    success: PropTypes.node,
-	    warning: PropTypes.node
-	  }),
-	  /**
-	   * Callback fired when the component requests to be closed.
-	   * When provided and no `action` prop is set, a close icon button is displayed that triggers the callback when clicked.
-	   * @param {React.SyntheticEvent} event The event source of the callback.
-	   */
-	  onClose: PropTypes.func,
-	  /**
-	   * The ARIA role attribute of the element.
-	   * @default 'alert'
-	   */
-	  role: PropTypes.string,
-	  /**
-	   * The severity of the alert. This defines the color and icon used.
-	   * @default 'success'
-	   */
-	  severity: PropTypes.oneOf(['error', 'info', 'success', 'warning']),
-	  /**
-	   * The extra props for the slot components.
-	   * You can override the existing props or add new ones.
-	   *
-	   * This prop is an alias for the `componentsProps` prop, which will be deprecated in the future.
-	   *
-	   * @default {}
-	   */
-	  slotProps: PropTypes.shape({
-	    closeButton: PropTypes.object,
-	    closeIcon: PropTypes.object
-	  }),
-	  /**
-	   * The components used for each slot inside.
-	   *
-	   * This prop is an alias for the `components` prop, which will be deprecated in the future.
-	   *
-	   * @default {}
-	   */
-	  slots: PropTypes.shape({
-	    closeButton: PropTypes.elementType,
-	    closeIcon: PropTypes.elementType
-	  }),
+	  row: PropTypes.bool,
 	  /**
 	   * The system prop that allows defining system overrides as well as additional CSS styles.
 	   */
-	  sx: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])), PropTypes.func, PropTypes.object]),
-	  /**
-	   * The variant to use.
-	   * @default 'standard'
-	   */
-	  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([PropTypes.oneOf(['filled', 'outlined', 'standard']), PropTypes.string])
+	  sx: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])), PropTypes.func, PropTypes.object])
 	} : void 0;
-	var Alert$1 = Alert;
+	var FormGroup$1 = FormGroup;
 
 	// Supports determination of isControlled().
 	// Controlled input accepts its current value as a prop.
@@ -58044,22 +57839,13 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  return obj.startAdornment;
 	}
 
-	/**
-	 * @ignore - internal component.
-	 */
-	const FormControlContext = /*#__PURE__*/reactExports.createContext(undefined);
-	if (process.env.NODE_ENV !== 'production') {
-	  FormControlContext.displayName = 'FormControlContext';
-	}
-	var FormControlContext$1 = FormControlContext;
-
 	function getFormControlUtilityClasses(slot) {
 	  return generateUtilityClass('MuiFormControl', slot);
 	}
 	generateUtilityClasses('MuiFormControl', ['root', 'marginNone', 'marginNormal', 'marginDense', 'fullWidth', 'disabled']);
 
-	const _excluded$p = ["children", "className", "color", "component", "disabled", "error", "focused", "fullWidth", "hiddenLabel", "margin", "required", "size", "variant"];
-	const useUtilityClasses$l = ownerState => {
+	const _excluded$q = ["children", "className", "color", "component", "disabled", "error", "focused", "fullWidth", "hiddenLabel", "margin", "required", "size", "variant"];
+	const useUtilityClasses$m = ownerState => {
 	  const {
 	    classes,
 	    margin,
@@ -58144,7 +57930,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      size = 'medium',
 	      variant = 'outlined'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$p);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$q);
 	  const ownerState = _extends$2({}, props, {
 	    color,
 	    component,
@@ -58157,7 +57943,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    size,
 	    variant
 	  });
-	  const classes = useUtilityClasses$l(ownerState);
+	  const classes = useUtilityClasses$m(ownerState);
 	  const [adornedStart, setAdornedStart] = reactExports.useState(() => {
 	    // We need to iterate through the children and find the Input in order
 	    // to fully support server-side rendering.
@@ -58333,10 +58119,6 @@ Please use another name.` : formatMuiErrorMessage(18));
 	} : void 0;
 	var FormControl$1 = FormControl;
 
-	function useFormControl() {
-	  return reactExports.useContext(FormControlContext$1);
-	}
-
 	const Stack = createStack({
 	  createStyledComponent: styled$1('div', {
 	    name: 'MuiStack',
@@ -58400,24 +58182,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const formControlLabelClasses = generateUtilityClasses('MuiFormControlLabel', ['root', 'labelPlacementStart', 'labelPlacementTop', 'labelPlacementBottom', 'disabled', 'label', 'error', 'required', 'asterisk']);
 	var formControlLabelClasses$1 = formControlLabelClasses;
 
-	function formControlState({
-	  props,
-	  states,
-	  muiFormControl
-	}) {
-	  return states.reduce((acc, state) => {
-	    acc[state] = props[state];
-	    if (muiFormControl) {
-	      if (typeof props[state] === 'undefined') {
-	        acc[state] = muiFormControl[state];
-	      }
-	    }
-	    return acc;
-	  }, {});
-	}
-
-	const _excluded$o = ["checked", "className", "componentsProps", "control", "disabled", "disableTypography", "inputRef", "label", "labelPlacement", "name", "onChange", "required", "slotProps", "value"];
-	const useUtilityClasses$k = ownerState => {
+	const _excluded$p = ["checked", "className", "componentsProps", "control", "disabled", "disableTypography", "inputRef", "label", "labelPlacement", "name", "onChange", "required", "slotProps", "value"];
+	const useUtilityClasses$l = ownerState => {
 	  const {
 	    classes,
 	    disabled,
@@ -58510,7 +58276,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      required: requiredProp,
 	      slotProps = {}
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$o);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$p);
 	  const muiFormControl = useFormControl();
 	  const disabled = (_ref = disabledProp != null ? disabledProp : control.props.disabled) != null ? _ref : muiFormControl == null ? void 0 : muiFormControl.disabled;
 	  const required = requiredProp != null ? requiredProp : control.props.required;
@@ -58534,7 +58300,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    required,
 	    error: fcs.error
 	  });
-	  const classes = useUtilityClasses$k(ownerState);
+	  const classes = useUtilityClasses$l(ownerState);
 	  const typographySlotProps = (_slotProps$typography = slotProps.typography) != null ? _slotProps$typography : componentsProps.typography;
 	  let label = labelProp;
 	  if (label != null && label.type !== Typography$1 && !disableTypography) {
@@ -58644,6 +58410,983 @@ Please use another name.` : formatMuiErrorMessage(18));
 	} : void 0;
 	var FormControlLabel$1 = FormControlLabel;
 
+	function getSwitchBaseUtilityClass(slot) {
+	  return generateUtilityClass('PrivateSwitchBase', slot);
+	}
+	generateUtilityClasses('PrivateSwitchBase', ['root', 'checked', 'disabled', 'input', 'edgeStart', 'edgeEnd']);
+
+	const _excluded$o = ["autoFocus", "checked", "checkedIcon", "className", "defaultChecked", "disabled", "disableFocusRipple", "edge", "icon", "id", "inputProps", "inputRef", "name", "onBlur", "onChange", "onFocus", "readOnly", "required", "tabIndex", "type", "value"];
+	const useUtilityClasses$k = ownerState => {
+	  const {
+	    classes,
+	    checked,
+	    disabled,
+	    edge
+	  } = ownerState;
+	  const slots = {
+	    root: ['root', checked && 'checked', disabled && 'disabled', edge && `edge${capitalize(edge)}`],
+	    input: ['input']
+	  };
+	  return composeClasses(slots, getSwitchBaseUtilityClass, classes);
+	};
+	const SwitchBaseRoot = styled$1(ButtonBase$1)(({
+	  ownerState
+	}) => _extends$2({
+	  padding: 9,
+	  borderRadius: '50%'
+	}, ownerState.edge === 'start' && {
+	  marginLeft: ownerState.size === 'small' ? -3 : -12
+	}, ownerState.edge === 'end' && {
+	  marginRight: ownerState.size === 'small' ? -3 : -12
+	}));
+	const SwitchBaseInput = styled$1('input')({
+	  cursor: 'inherit',
+	  position: 'absolute',
+	  opacity: 0,
+	  width: '100%',
+	  height: '100%',
+	  top: 0,
+	  left: 0,
+	  margin: 0,
+	  padding: 0,
+	  zIndex: 1
+	});
+
+	/**
+	 * @ignore - internal component.
+	 */
+	const SwitchBase = /*#__PURE__*/reactExports.forwardRef(function SwitchBase(props, ref) {
+	  const {
+	      autoFocus,
+	      checked: checkedProp,
+	      checkedIcon,
+	      className,
+	      defaultChecked,
+	      disabled: disabledProp,
+	      disableFocusRipple = false,
+	      edge = false,
+	      icon,
+	      id,
+	      inputProps,
+	      inputRef,
+	      name,
+	      onBlur,
+	      onChange,
+	      onFocus,
+	      readOnly,
+	      required = false,
+	      tabIndex,
+	      type,
+	      value
+	    } = props,
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$o);
+	  const [checked, setCheckedState] = useControlled({
+	    controlled: checkedProp,
+	    default: Boolean(defaultChecked),
+	    name: 'SwitchBase',
+	    state: 'checked'
+	  });
+	  const muiFormControl = useFormControl();
+	  const handleFocus = event => {
+	    if (onFocus) {
+	      onFocus(event);
+	    }
+	    if (muiFormControl && muiFormControl.onFocus) {
+	      muiFormControl.onFocus(event);
+	    }
+	  };
+	  const handleBlur = event => {
+	    if (onBlur) {
+	      onBlur(event);
+	    }
+	    if (muiFormControl && muiFormControl.onBlur) {
+	      muiFormControl.onBlur(event);
+	    }
+	  };
+	  const handleInputChange = event => {
+	    // Workaround for https://github.com/facebook/react/issues/9023
+	    if (event.nativeEvent.defaultPrevented) {
+	      return;
+	    }
+	    const newChecked = event.target.checked;
+	    setCheckedState(newChecked);
+	    if (onChange) {
+	      // TODO v6: remove the second argument.
+	      onChange(event, newChecked);
+	    }
+	  };
+	  let disabled = disabledProp;
+	  if (muiFormControl) {
+	    if (typeof disabled === 'undefined') {
+	      disabled = muiFormControl.disabled;
+	    }
+	  }
+	  const hasLabelFor = type === 'checkbox' || type === 'radio';
+	  const ownerState = _extends$2({}, props, {
+	    checked,
+	    disabled,
+	    disableFocusRipple,
+	    edge
+	  });
+	  const classes = useUtilityClasses$k(ownerState);
+	  return /*#__PURE__*/jsxRuntimeExports.jsxs(SwitchBaseRoot, _extends$2({
+	    component: "span",
+	    className: clsx(classes.root, className),
+	    centerRipple: true,
+	    focusRipple: !disableFocusRipple,
+	    disabled: disabled,
+	    tabIndex: null,
+	    role: undefined,
+	    onFocus: handleFocus,
+	    onBlur: handleBlur,
+	    ownerState: ownerState,
+	    ref: ref
+	  }, other, {
+	    children: [/*#__PURE__*/jsxRuntimeExports.jsx(SwitchBaseInput, _extends$2({
+	      autoFocus: autoFocus,
+	      checked: checkedProp,
+	      defaultChecked: defaultChecked,
+	      className: classes.input,
+	      disabled: disabled,
+	      id: hasLabelFor ? id : undefined,
+	      name: name,
+	      onChange: handleInputChange,
+	      readOnly: readOnly,
+	      ref: inputRef,
+	      required: required,
+	      ownerState: ownerState,
+	      tabIndex: tabIndex,
+	      type: type
+	    }, type === 'checkbox' && value === undefined ? {} : {
+	      value
+	    }, inputProps)), checked ? checkedIcon : icon]
+	  }));
+	});
+
+	// NB: If changed, please update Checkbox, Switch and Radio
+	// so that the API documentation is updated.
+	process.env.NODE_ENV !== "production" ? SwitchBase.propTypes = {
+	  /**
+	   * If `true`, the `input` element is focused during the first mount.
+	   */
+	  autoFocus: PropTypes.bool,
+	  /**
+	   * If `true`, the component is checked.
+	   */
+	  checked: PropTypes.bool,
+	  /**
+	   * The icon to display when the component is checked.
+	   */
+	  checkedIcon: PropTypes.node.isRequired,
+	  /**
+	   * Override or extend the styles applied to the component.
+	   * See [CSS API](#css) below for more details.
+	   */
+	  classes: PropTypes.object,
+	  /**
+	   * @ignore
+	   */
+	  className: PropTypes.string,
+	  /**
+	   * @ignore
+	   */
+	  defaultChecked: PropTypes.bool,
+	  /**
+	   * If `true`, the component is disabled.
+	   */
+	  disabled: PropTypes.bool,
+	  /**
+	   * If `true`, the  keyboard focus ripple is disabled.
+	   * @default false
+	   */
+	  disableFocusRipple: PropTypes.bool,
+	  /**
+	   * If given, uses a negative margin to counteract the padding on one
+	   * side (this is often helpful for aligning the left or right
+	   * side of the icon with content above or below, without ruining the border
+	   * size and shape).
+	   * @default false
+	   */
+	  edge: PropTypes.oneOf(['end', 'start', false]),
+	  /**
+	   * The icon to display when the component is unchecked.
+	   */
+	  icon: PropTypes.node.isRequired,
+	  /**
+	   * The id of the `input` element.
+	   */
+	  id: PropTypes.string,
+	  /**
+	   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+	   */
+	  inputProps: PropTypes.object,
+	  /**
+	   * Pass a ref to the `input` element.
+	   */
+	  inputRef: refType$1,
+	  /*
+	   * @ignore
+	   */
+	  name: PropTypes.string,
+	  /**
+	   * @ignore
+	   */
+	  onBlur: PropTypes.func,
+	  /**
+	   * Callback fired when the state is changed.
+	   *
+	   * @param {object} event The event source of the callback.
+	   * You can pull out the new checked state by accessing `event.target.checked` (boolean).
+	   */
+	  onChange: PropTypes.func,
+	  /**
+	   * @ignore
+	   */
+	  onFocus: PropTypes.func,
+	  /**
+	   * It prevents the user from changing the value of the field
+	   * (not from interacting with the field).
+	   */
+	  readOnly: PropTypes.bool,
+	  /**
+	   * If `true`, the `input` element is required.
+	   */
+	  required: PropTypes.bool,
+	  /**
+	   * The system prop that allows defining system overrides as well as additional CSS styles.
+	   */
+	  sx: PropTypes.object,
+	  /**
+	   * @ignore
+	   */
+	  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	  /**
+	   * The input component prop `type`.
+	   */
+	  type: PropTypes.string.isRequired,
+	  /**
+	   * The value of the component.
+	   */
+	  value: PropTypes.any
+	} : void 0;
+	var SwitchBase$1 = SwitchBase;
+
+	function getSwitchUtilityClass(slot) {
+	  return generateUtilityClass('MuiSwitch', slot);
+	}
+	const switchClasses = generateUtilityClasses('MuiSwitch', ['root', 'edgeStart', 'edgeEnd', 'switchBase', 'colorPrimary', 'colorSecondary', 'sizeSmall', 'sizeMedium', 'checked', 'disabled', 'input', 'thumb', 'track']);
+	var switchClasses$1 = switchClasses;
+
+	const _excluded$n = ["className", "color", "edge", "size", "sx"];
+	const useUtilityClasses$j = ownerState => {
+	  const {
+	    classes,
+	    edge,
+	    size,
+	    color,
+	    checked,
+	    disabled
+	  } = ownerState;
+	  const slots = {
+	    root: ['root', edge && `edge${capitalize(edge)}`, `size${capitalize(size)}`],
+	    switchBase: ['switchBase', `color${capitalize(color)}`, checked && 'checked', disabled && 'disabled'],
+	    thumb: ['thumb'],
+	    track: ['track'],
+	    input: ['input']
+	  };
+	  const composedClasses = composeClasses(slots, getSwitchUtilityClass, classes);
+	  return _extends$2({}, classes, composedClasses);
+	};
+	const SwitchRoot = styled$1('span', {
+	  name: 'MuiSwitch',
+	  slot: 'Root',
+	  overridesResolver: (props, styles) => {
+	    const {
+	      ownerState
+	    } = props;
+	    return [styles.root, ownerState.edge && styles[`edge${capitalize(ownerState.edge)}`], styles[`size${capitalize(ownerState.size)}`]];
+	  }
+	})(({
+	  ownerState
+	}) => _extends$2({
+	  display: 'inline-flex',
+	  width: 34 + 12 * 2,
+	  height: 14 + 12 * 2,
+	  overflow: 'hidden',
+	  padding: 12,
+	  boxSizing: 'border-box',
+	  position: 'relative',
+	  flexShrink: 0,
+	  zIndex: 0,
+	  // Reset the stacking context.
+	  verticalAlign: 'middle',
+	  // For correct alignment with the text.
+	  '@media print': {
+	    colorAdjust: 'exact'
+	  }
+	}, ownerState.edge === 'start' && {
+	  marginLeft: -8
+	}, ownerState.edge === 'end' && {
+	  marginRight: -8
+	}, ownerState.size === 'small' && {
+	  width: 40,
+	  height: 24,
+	  padding: 7,
+	  [`& .${switchClasses$1.thumb}`]: {
+	    width: 16,
+	    height: 16
+	  },
+	  [`& .${switchClasses$1.switchBase}`]: {
+	    padding: 4,
+	    [`&.${switchClasses$1.checked}`]: {
+	      transform: 'translateX(16px)'
+	    }
+	  }
+	}));
+	const SwitchSwitchBase = styled$1(SwitchBase$1, {
+	  name: 'MuiSwitch',
+	  slot: 'SwitchBase',
+	  overridesResolver: (props, styles) => {
+	    const {
+	      ownerState
+	    } = props;
+	    return [styles.switchBase, {
+	      [`& .${switchClasses$1.input}`]: styles.input
+	    }, ownerState.color !== 'default' && styles[`color${capitalize(ownerState.color)}`]];
+	  }
+	})(({
+	  theme
+	}) => ({
+	  position: 'absolute',
+	  top: 0,
+	  left: 0,
+	  zIndex: 1,
+	  // Render above the focus ripple.
+	  color: theme.vars ? theme.vars.palette.Switch.defaultColor : `${theme.palette.mode === 'light' ? theme.palette.common.white : theme.palette.grey[300]}`,
+	  transition: theme.transitions.create(['left', 'transform'], {
+	    duration: theme.transitions.duration.shortest
+	  }),
+	  [`&.${switchClasses$1.checked}`]: {
+	    transform: 'translateX(20px)'
+	  },
+	  [`&.${switchClasses$1.disabled}`]: {
+	    color: theme.vars ? theme.vars.palette.Switch.defaultDisabledColor : `${theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[600]}`
+	  },
+	  [`&.${switchClasses$1.checked} + .${switchClasses$1.track}`]: {
+	    opacity: 0.5
+	  },
+	  [`&.${switchClasses$1.disabled} + .${switchClasses$1.track}`]: {
+	    opacity: theme.vars ? theme.vars.opacity.switchTrackDisabled : `${theme.palette.mode === 'light' ? 0.12 : 0.2}`
+	  },
+	  [`& .${switchClasses$1.input}`]: {
+	    left: '-100%',
+	    width: '300%'
+	  }
+	}), ({
+	  theme,
+	  ownerState
+	}) => _extends$2({
+	  '&:hover': {
+	    backgroundColor: theme.vars ? `rgba(${theme.vars.palette.action.activeChannel} / ${theme.vars.palette.action.hoverOpacity})` : alpha(theme.palette.action.active, theme.palette.action.hoverOpacity),
+	    // Reset on touch devices, it doesn't add specificity
+	    '@media (hover: none)': {
+	      backgroundColor: 'transparent'
+	    }
+	  }
+	}, ownerState.color !== 'default' && {
+	  [`&.${switchClasses$1.checked}`]: {
+	    color: (theme.vars || theme).palette[ownerState.color].main,
+	    '&:hover': {
+	      backgroundColor: theme.vars ? `rgba(${theme.vars.palette[ownerState.color].mainChannel} / ${theme.vars.palette.action.hoverOpacity})` : alpha(theme.palette[ownerState.color].main, theme.palette.action.hoverOpacity),
+	      '@media (hover: none)': {
+	        backgroundColor: 'transparent'
+	      }
+	    },
+	    [`&.${switchClasses$1.disabled}`]: {
+	      color: theme.vars ? theme.vars.palette.Switch[`${ownerState.color}DisabledColor`] : `${theme.palette.mode === 'light' ? lighten(theme.palette[ownerState.color].main, 0.62) : darken(theme.palette[ownerState.color].main, 0.55)}`
+	    }
+	  },
+	  [`&.${switchClasses$1.checked} + .${switchClasses$1.track}`]: {
+	    backgroundColor: (theme.vars || theme).palette[ownerState.color].main
+	  }
+	}));
+	const SwitchTrack = styled$1('span', {
+	  name: 'MuiSwitch',
+	  slot: 'Track',
+	  overridesResolver: (props, styles) => styles.track
+	})(({
+	  theme
+	}) => ({
+	  height: '100%',
+	  width: '100%',
+	  borderRadius: 14 / 2,
+	  zIndex: -1,
+	  transition: theme.transitions.create(['opacity', 'background-color'], {
+	    duration: theme.transitions.duration.shortest
+	  }),
+	  backgroundColor: theme.vars ? theme.vars.palette.common.onBackground : `${theme.palette.mode === 'light' ? theme.palette.common.black : theme.palette.common.white}`,
+	  opacity: theme.vars ? theme.vars.opacity.switchTrack : `${theme.palette.mode === 'light' ? 0.38 : 0.3}`
+	}));
+	const SwitchThumb = styled$1('span', {
+	  name: 'MuiSwitch',
+	  slot: 'Thumb',
+	  overridesResolver: (props, styles) => styles.thumb
+	})(({
+	  theme
+	}) => ({
+	  boxShadow: (theme.vars || theme).shadows[1],
+	  backgroundColor: 'currentColor',
+	  width: 20,
+	  height: 20,
+	  borderRadius: '50%'
+	}));
+	const Switch = /*#__PURE__*/reactExports.forwardRef(function Switch(inProps, ref) {
+	  const props = useThemeProps({
+	    props: inProps,
+	    name: 'MuiSwitch'
+	  });
+	  const {
+	      className,
+	      color = 'primary',
+	      edge = false,
+	      size = 'medium',
+	      sx
+	    } = props,
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$n);
+	  const ownerState = _extends$2({}, props, {
+	    color,
+	    edge,
+	    size
+	  });
+	  const classes = useUtilityClasses$j(ownerState);
+	  const icon = /*#__PURE__*/jsxRuntimeExports.jsx(SwitchThumb, {
+	    className: classes.thumb,
+	    ownerState: ownerState
+	  });
+	  return /*#__PURE__*/jsxRuntimeExports.jsxs(SwitchRoot, {
+	    className: clsx(classes.root, className),
+	    sx: sx,
+	    ownerState: ownerState,
+	    children: [/*#__PURE__*/jsxRuntimeExports.jsx(SwitchSwitchBase, _extends$2({
+	      type: "checkbox",
+	      icon: icon,
+	      checkedIcon: icon,
+	      ref: ref,
+	      ownerState: ownerState
+	    }, other, {
+	      classes: _extends$2({}, classes, {
+	        root: classes.switchBase
+	      })
+	    })), /*#__PURE__*/jsxRuntimeExports.jsx(SwitchTrack, {
+	      className: classes.track,
+	      ownerState: ownerState
+	    })]
+	  });
+	});
+	process.env.NODE_ENV !== "production" ? Switch.propTypes /* remove-proptypes */ = {
+	  // ----------------------------- Warning --------------------------------
+	  // | These PropTypes are generated from the TypeScript type definitions |
+	  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+	  // ----------------------------------------------------------------------
+	  /**
+	   * If `true`, the component is checked.
+	   */
+	  checked: PropTypes.bool,
+	  /**
+	   * The icon to display when the component is checked.
+	   */
+	  checkedIcon: PropTypes.node,
+	  /**
+	   * Override or extend the styles applied to the component.
+	   */
+	  classes: PropTypes.object,
+	  /**
+	   * @ignore
+	   */
+	  className: PropTypes.string,
+	  /**
+	   * The color of the component.
+	   * It supports both default and custom theme colors, which can be added as shown in the
+	   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+	   * @default 'primary'
+	   */
+	  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([PropTypes.oneOf(['default', 'primary', 'secondary', 'error', 'info', 'success', 'warning']), PropTypes.string]),
+	  /**
+	   * The default checked state. Use when the component is not controlled.
+	   */
+	  defaultChecked: PropTypes.bool,
+	  /**
+	   * If `true`, the component is disabled.
+	   */
+	  disabled: PropTypes.bool,
+	  /**
+	   * If `true`, the ripple effect is disabled.
+	   * @default false
+	   */
+	  disableRipple: PropTypes.bool,
+	  /**
+	   * If given, uses a negative margin to counteract the padding on one
+	   * side (this is often helpful for aligning the left or right
+	   * side of the icon with content above or below, without ruining the border
+	   * size and shape).
+	   * @default false
+	   */
+	  edge: PropTypes.oneOf(['end', 'start', false]),
+	  /**
+	   * The icon to display when the component is unchecked.
+	   */
+	  icon: PropTypes.node,
+	  /**
+	   * The id of the `input` element.
+	   */
+	  id: PropTypes.string,
+	  /**
+	   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+	   */
+	  inputProps: PropTypes.object,
+	  /**
+	   * Pass a ref to the `input` element.
+	   */
+	  inputRef: refType$1,
+	  /**
+	   * Callback fired when the state is changed.
+	   *
+	   * @param {React.ChangeEvent<HTMLInputElement>} event The event source of the callback.
+	   * You can pull out the new value by accessing `event.target.value` (string).
+	   * You can pull out the new checked state by accessing `event.target.checked` (boolean).
+	   */
+	  onChange: PropTypes.func,
+	  /**
+	   * If `true`, the `input` element is required.
+	   * @default false
+	   */
+	  required: PropTypes.bool,
+	  /**
+	   * The size of the component.
+	   * `small` is equivalent to the dense switch styling.
+	   * @default 'medium'
+	   */
+	  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.string]),
+	  /**
+	   * The system prop that allows defining system overrides as well as additional CSS styles.
+	   */
+	  sx: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])), PropTypes.func, PropTypes.object]),
+	  /**
+	   * The value of the component. The DOM API casts this to a string.
+	   * The browser uses "on" as the default value.
+	   */
+	  value: PropTypes.any
+	} : void 0;
+	var Switch$1 = Switch;
+
+	const PageTitle$1 = styled$1(Box$1)(({
+	  theme
+	}) => ({
+	  paddingTop: theme.spacing(4),
+	  paddingBottom: theme.spacing(6),
+	  '& .MuiTypography-h1': {
+	    color: 'currentColor',
+	    fontWeight: 400,
+	    fontSize: '34px'
+	  }
+	}));
+
+	// NOTE: Using reducer here in anitipation of more complex settings page
+	// with various different controls
+	function reducer(state, action) {
+	  switch (action.type) {
+	    case 'SET_INITIAL_STATE':
+	      return {
+	        ...state,
+	        ...action.payload
+	      };
+	    case 'SET_UPDATES':
+	      return {
+	        ...state,
+	        updates: action.value
+	      };
+	  }
+	  return state;
+	}
+	const NotificationsSettingsPage = () => {
+	  const [state, dispatch] = reactExports.useReducer(reducer, {
+	    updates: false
+	  });
+	  const [apiData, loading, error] = useApi(COURSEFLOW_APP.config.json_api_paths.update_notifications_settings);
+
+	  // after the apiData is loaded in, set it as state so it can be used internally
+	  reactExports.useEffect(() => {
+	    if (!loading) {
+	      dispatch({
+	        type: 'SET_INITIAL_STATE',
+	        payload: apiData
+	      });
+	    }
+	  }, [loading]);
+	  if (loading || error) {
+	    return null;
+	  }
+	  function onUpdatesSwitchChange(e) {
+	    const newState = {
+	      ...state,
+	      updates: !state.updates
+	    };
+
+	    // post to the appropriate URL
+	    API_POST(COURSEFLOW_APP.config.json_api_paths.update_notifications_settings, newState).then(response => {
+	      console.log('API_POST\n', newState, '\nto\n', COURSEFLOW_APP.config.json_api_paths.update_notifications_settings, '\ngot\n', response);
+
+	      // and if successful, dispatch the action to update local state
+	      dispatch({
+	        type: 'SET_UPDATES',
+	        value: !state.updates
+	      });
+	    });
+	  }
+	  return /*#__PURE__*/React.createElement(OuterContentWrap, {
+	    narrow: true
+	  }, /*#__PURE__*/React.createElement(PageTitle$1, null, /*#__PURE__*/React.createElement(Typography$1, {
+	    variant: "h1"
+	  }, COURSEFLOW_APP.strings.notification_settings)), /*#__PURE__*/React.createElement(FormGroup$1, null, /*#__PURE__*/React.createElement(FormControlLabel$1, {
+	    control: /*#__PURE__*/React.createElement(Switch$1, {
+	      checked: state.updates,
+	      onChange: onUpdatesSwitchChange
+	    }),
+	    label: COURSEFLOW_APP.strings.product_updates_agree
+	  })));
+	};
+
+	function getAlertUtilityClass(slot) {
+	  return generateUtilityClass('MuiAlert', slot);
+	}
+	const alertClasses = generateUtilityClasses('MuiAlert', ['root', 'action', 'icon', 'message', 'filled', 'filledSuccess', 'filledInfo', 'filledWarning', 'filledError', 'outlined', 'outlinedSuccess', 'outlinedInfo', 'outlinedWarning', 'outlinedError', 'standard', 'standardSuccess', 'standardInfo', 'standardWarning', 'standardError']);
+	var alertClasses$1 = alertClasses;
+
+	var SuccessOutlinedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
+	  d: "M20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4C12.76,4 13.5,4.11 14.2, 4.31L15.77,2.74C14.61,2.26 13.34,2 12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0, 0 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
+	}), 'SuccessOutlined');
+
+	var ReportProblemOutlinedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
+	  d: "M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+	}), 'ReportProblemOutlined');
+
+	var ErrorOutlineIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
+	  d: "M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+	}), 'ErrorOutline');
+
+	var InfoOutlinedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
+	  d: "M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20, 12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10, 10 0 0,0 12,2M11,17H13V11H11V17Z"
+	}), 'InfoOutlined');
+
+	var CloseIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
+	  d: "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+	}), 'Close');
+
+	const _excluded$m = ["action", "children", "className", "closeText", "color", "components", "componentsProps", "icon", "iconMapping", "onClose", "role", "severity", "slotProps", "slots", "variant"];
+	const useUtilityClasses$i = ownerState => {
+	  const {
+	    variant,
+	    color,
+	    severity,
+	    classes
+	  } = ownerState;
+	  const slots = {
+	    root: ['root', `${variant}${capitalize(color || severity)}`, `${variant}`],
+	    icon: ['icon'],
+	    message: ['message'],
+	    action: ['action']
+	  };
+	  return composeClasses(slots, getAlertUtilityClass, classes);
+	};
+	const AlertRoot = styled$1(Paper$1, {
+	  name: 'MuiAlert',
+	  slot: 'Root',
+	  overridesResolver: (props, styles) => {
+	    const {
+	      ownerState
+	    } = props;
+	    return [styles.root, styles[ownerState.variant], styles[`${ownerState.variant}${capitalize(ownerState.color || ownerState.severity)}`]];
+	  }
+	})(({
+	  theme,
+	  ownerState
+	}) => {
+	  const getColor = theme.palette.mode === 'light' ? darken : lighten;
+	  const getBackgroundColor = theme.palette.mode === 'light' ? lighten : darken;
+	  const color = ownerState.color || ownerState.severity;
+	  return _extends$2({}, theme.typography.body2, {
+	    backgroundColor: 'transparent',
+	    display: 'flex',
+	    padding: '6px 16px'
+	  }, color && ownerState.variant === 'standard' && {
+	    color: theme.vars ? theme.vars.palette.Alert[`${color}Color`] : getColor(theme.palette[color].light, 0.6),
+	    backgroundColor: theme.vars ? theme.vars.palette.Alert[`${color}StandardBg`] : getBackgroundColor(theme.palette[color].light, 0.9),
+	    [`& .${alertClasses$1.icon}`]: theme.vars ? {
+	      color: theme.vars.palette.Alert[`${color}IconColor`]
+	    } : {
+	      color: theme.palette[color].main
+	    }
+	  }, color && ownerState.variant === 'outlined' && {
+	    color: theme.vars ? theme.vars.palette.Alert[`${color}Color`] : getColor(theme.palette[color].light, 0.6),
+	    border: `1px solid ${(theme.vars || theme).palette[color].light}`,
+	    [`& .${alertClasses$1.icon}`]: theme.vars ? {
+	      color: theme.vars.palette.Alert[`${color}IconColor`]
+	    } : {
+	      color: theme.palette[color].main
+	    }
+	  }, color && ownerState.variant === 'filled' && _extends$2({
+	    fontWeight: theme.typography.fontWeightMedium
+	  }, theme.vars ? {
+	    color: theme.vars.palette.Alert[`${color}FilledColor`],
+	    backgroundColor: theme.vars.palette.Alert[`${color}FilledBg`]
+	  } : {
+	    backgroundColor: theme.palette.mode === 'dark' ? theme.palette[color].dark : theme.palette[color].main,
+	    color: theme.palette.getContrastText(theme.palette[color].main)
+	  }));
+	});
+	const AlertIcon = styled$1('div', {
+	  name: 'MuiAlert',
+	  slot: 'Icon',
+	  overridesResolver: (props, styles) => styles.icon
+	})({
+	  marginRight: 12,
+	  padding: '7px 0',
+	  display: 'flex',
+	  fontSize: 22,
+	  opacity: 0.9
+	});
+	const AlertMessage = styled$1('div', {
+	  name: 'MuiAlert',
+	  slot: 'Message',
+	  overridesResolver: (props, styles) => styles.message
+	})({
+	  padding: '8px 0',
+	  minWidth: 0,
+	  overflow: 'auto'
+	});
+	const AlertAction = styled$1('div', {
+	  name: 'MuiAlert',
+	  slot: 'Action',
+	  overridesResolver: (props, styles) => styles.action
+	})({
+	  display: 'flex',
+	  alignItems: 'flex-start',
+	  padding: '4px 0 0 16px',
+	  marginLeft: 'auto',
+	  marginRight: -8
+	});
+	const defaultIconMapping = {
+	  success: /*#__PURE__*/jsxRuntimeExports.jsx(SuccessOutlinedIcon, {
+	    fontSize: "inherit"
+	  }),
+	  warning: /*#__PURE__*/jsxRuntimeExports.jsx(ReportProblemOutlinedIcon, {
+	    fontSize: "inherit"
+	  }),
+	  error: /*#__PURE__*/jsxRuntimeExports.jsx(ErrorOutlineIcon, {
+	    fontSize: "inherit"
+	  }),
+	  info: /*#__PURE__*/jsxRuntimeExports.jsx(InfoOutlinedIcon, {
+	    fontSize: "inherit"
+	  })
+	};
+	const Alert = /*#__PURE__*/reactExports.forwardRef(function Alert(inProps, ref) {
+	  var _ref, _slots$closeButton, _ref2, _slots$closeIcon, _slotProps$closeButto, _slotProps$closeIcon;
+	  const props = useThemeProps({
+	    props: inProps,
+	    name: 'MuiAlert'
+	  });
+	  const {
+	      action,
+	      children,
+	      className,
+	      closeText = 'Close',
+	      color,
+	      components = {},
+	      componentsProps = {},
+	      icon,
+	      iconMapping = defaultIconMapping,
+	      onClose,
+	      role = 'alert',
+	      severity = 'success',
+	      slotProps = {},
+	      slots = {},
+	      variant = 'standard'
+	    } = props,
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$m);
+	  const ownerState = _extends$2({}, props, {
+	    color,
+	    severity,
+	    variant
+	  });
+	  const classes = useUtilityClasses$i(ownerState);
+	  const AlertCloseButton = (_ref = (_slots$closeButton = slots.closeButton) != null ? _slots$closeButton : components.CloseButton) != null ? _ref : IconButton$1;
+	  const AlertCloseIcon = (_ref2 = (_slots$closeIcon = slots.closeIcon) != null ? _slots$closeIcon : components.CloseIcon) != null ? _ref2 : CloseIcon;
+	  const closeButtonProps = (_slotProps$closeButto = slotProps.closeButton) != null ? _slotProps$closeButto : componentsProps.closeButton;
+	  const closeIconProps = (_slotProps$closeIcon = slotProps.closeIcon) != null ? _slotProps$closeIcon : componentsProps.closeIcon;
+	  return /*#__PURE__*/jsxRuntimeExports.jsxs(AlertRoot, _extends$2({
+	    role: role,
+	    elevation: 0,
+	    ownerState: ownerState,
+	    className: clsx(classes.root, className),
+	    ref: ref
+	  }, other, {
+	    children: [icon !== false ? /*#__PURE__*/jsxRuntimeExports.jsx(AlertIcon, {
+	      ownerState: ownerState,
+	      className: classes.icon,
+	      children: icon || iconMapping[severity] || defaultIconMapping[severity]
+	    }) : null, /*#__PURE__*/jsxRuntimeExports.jsx(AlertMessage, {
+	      ownerState: ownerState,
+	      className: classes.message,
+	      children: children
+	    }), action != null ? /*#__PURE__*/jsxRuntimeExports.jsx(AlertAction, {
+	      ownerState: ownerState,
+	      className: classes.action,
+	      children: action
+	    }) : null, action == null && onClose ? /*#__PURE__*/jsxRuntimeExports.jsx(AlertAction, {
+	      ownerState: ownerState,
+	      className: classes.action,
+	      children: /*#__PURE__*/jsxRuntimeExports.jsx(AlertCloseButton, _extends$2({
+	        size: "small",
+	        "aria-label": closeText,
+	        title: closeText,
+	        color: "inherit",
+	        onClick: onClose
+	      }, closeButtonProps, {
+	        children: /*#__PURE__*/jsxRuntimeExports.jsx(AlertCloseIcon, _extends$2({
+	          fontSize: "small"
+	        }, closeIconProps))
+	      }))
+	    }) : null]
+	  }));
+	});
+	process.env.NODE_ENV !== "production" ? Alert.propTypes /* remove-proptypes */ = {
+	  // ----------------------------- Warning --------------------------------
+	  // | These PropTypes are generated from the TypeScript type definitions |
+	  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+	  // ----------------------------------------------------------------------
+	  /**
+	   * The action to display. It renders after the message, at the end of the alert.
+	   */
+	  action: PropTypes.node,
+	  /**
+	   * The content of the component.
+	   */
+	  children: PropTypes.node,
+	  /**
+	   * Override or extend the styles applied to the component.
+	   */
+	  classes: PropTypes.object,
+	  /**
+	   * @ignore
+	   */
+	  className: PropTypes.string,
+	  /**
+	   * Override the default label for the *close popup* icon button.
+	   *
+	   * For localization purposes, you can use the provided [translations](/material-ui/guides/localization/).
+	   * @default 'Close'
+	   */
+	  closeText: PropTypes.string,
+	  /**
+	   * The color of the component. Unless provided, the value is taken from the `severity` prop.
+	   * It supports both default and custom theme colors, which can be added as shown in the
+	   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+	   */
+	  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([PropTypes.oneOf(['error', 'info', 'success', 'warning']), PropTypes.string]),
+	  /**
+	   * The components used for each slot inside.
+	   *
+	   * This prop is an alias for the `slots` prop.
+	   * It's recommended to use the `slots` prop instead.
+	   *
+	   * @default {}
+	   */
+	  components: PropTypes.shape({
+	    CloseButton: PropTypes.elementType,
+	    CloseIcon: PropTypes.elementType
+	  }),
+	  /**
+	   * The extra props for the slot components.
+	   * You can override the existing props or add new ones.
+	   *
+	   * This prop is an alias for the `slotProps` prop.
+	   * It's recommended to use the `slotProps` prop instead, as `componentsProps` will be deprecated in the future.
+	   *
+	   * @default {}
+	   */
+	  componentsProps: PropTypes.shape({
+	    closeButton: PropTypes.object,
+	    closeIcon: PropTypes.object
+	  }),
+	  /**
+	   * Override the icon displayed before the children.
+	   * Unless provided, the icon is mapped to the value of the `severity` prop.
+	   * Set to `false` to remove the `icon`.
+	   */
+	  icon: PropTypes.node,
+	  /**
+	   * The component maps the `severity` prop to a range of different icons,
+	   * for instance success to `<SuccessOutlined>`.
+	   * If you wish to change this mapping, you can provide your own.
+	   * Alternatively, you can use the `icon` prop to override the icon displayed.
+	   */
+	  iconMapping: PropTypes.shape({
+	    error: PropTypes.node,
+	    info: PropTypes.node,
+	    success: PropTypes.node,
+	    warning: PropTypes.node
+	  }),
+	  /**
+	   * Callback fired when the component requests to be closed.
+	   * When provided and no `action` prop is set, a close icon button is displayed that triggers the callback when clicked.
+	   * @param {React.SyntheticEvent} event The event source of the callback.
+	   */
+	  onClose: PropTypes.func,
+	  /**
+	   * The ARIA role attribute of the element.
+	   * @default 'alert'
+	   */
+	  role: PropTypes.string,
+	  /**
+	   * The severity of the alert. This defines the color and icon used.
+	   * @default 'success'
+	   */
+	  severity: PropTypes.oneOf(['error', 'info', 'success', 'warning']),
+	  /**
+	   * The extra props for the slot components.
+	   * You can override the existing props or add new ones.
+	   *
+	   * This prop is an alias for the `componentsProps` prop, which will be deprecated in the future.
+	   *
+	   * @default {}
+	   */
+	  slotProps: PropTypes.shape({
+	    closeButton: PropTypes.object,
+	    closeIcon: PropTypes.object
+	  }),
+	  /**
+	   * The components used for each slot inside.
+	   *
+	   * This prop is an alias for the `components` prop, which will be deprecated in the future.
+	   *
+	   * @default {}
+	   */
+	  slots: PropTypes.shape({
+	    closeButton: PropTypes.elementType,
+	    closeIcon: PropTypes.elementType
+	  }),
+	  /**
+	   * The system prop that allows defining system overrides as well as additional CSS styles.
+	   */
+	  sx: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])), PropTypes.func, PropTypes.object]),
+	  /**
+	   * The variant to use.
+	   * @default 'standard'
+	   */
+	  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([PropTypes.oneOf(['filled', 'outlined', 'standard']), PropTypes.string])
+	} : void 0;
+	var Alert$1 = Alert;
+
 	function getFormHelperTextUtilityClasses(slot) {
 	  return generateUtilityClass('MuiFormHelperText', slot);
 	}
@@ -58651,8 +59394,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	var formHelperTextClasses$1 = formHelperTextClasses;
 
 	var _span$2;
-	const _excluded$n = ["children", "className", "component", "disabled", "error", "filled", "focused", "margin", "required", "variant"];
-	const useUtilityClasses$j = ownerState => {
+	const _excluded$l = ["children", "className", "component", "disabled", "error", "filled", "focused", "margin", "required", "variant"];
+	const useUtilityClasses$h = ownerState => {
 	  const {
 	    classes,
 	    contained,
@@ -58710,7 +59453,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      className,
 	      component = 'p'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$n);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$l);
 	  const muiFormControl = useFormControl();
 	  const fcs = formControlState({
 	    props,
@@ -58728,7 +59471,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    focused: fcs.focused,
 	    required: fcs.required
 	  });
-	  const classes = useUtilityClasses$j(ownerState);
+	  const classes = useUtilityClasses$h(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(FormHelperTextRoot, _extends$2({
 	    as: component,
 	    ownerState: ownerState,
@@ -58808,7 +59551,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const inputBaseClasses = generateUtilityClasses('MuiInputBase', ['root', 'formControl', 'focused', 'disabled', 'adornedStart', 'adornedEnd', 'error', 'sizeSmall', 'multiline', 'colorSecondary', 'fullWidth', 'hiddenLabel', 'readOnly', 'input', 'inputSizeSmall', 'inputMultiline', 'inputTypeSearch', 'inputAdornedStart', 'inputAdornedEnd', 'inputHiddenLabel']);
 	var inputBaseClasses$1 = inputBaseClasses;
 
-	const _excluded$m = ["aria-describedby", "autoComplete", "autoFocus", "className", "color", "components", "componentsProps", "defaultValue", "disabled", "disableInjectingGlobalStyles", "endAdornment", "error", "fullWidth", "id", "inputComponent", "inputProps", "inputRef", "margin", "maxRows", "minRows", "multiline", "name", "onBlur", "onChange", "onClick", "onFocus", "onKeyDown", "onKeyUp", "placeholder", "readOnly", "renderSuffix", "rows", "size", "slotProps", "slots", "startAdornment", "type", "value"];
+	const _excluded$k = ["aria-describedby", "autoComplete", "autoFocus", "className", "color", "components", "componentsProps", "defaultValue", "disabled", "disableInjectingGlobalStyles", "endAdornment", "error", "fullWidth", "id", "inputComponent", "inputProps", "inputRef", "margin", "maxRows", "minRows", "multiline", "name", "onBlur", "onChange", "onClick", "onFocus", "onKeyDown", "onKeyUp", "placeholder", "readOnly", "renderSuffix", "rows", "size", "slotProps", "slots", "startAdornment", "type", "value"];
 	const rootOverridesResolver = (props, styles) => {
 	  const {
 	    ownerState
@@ -58821,7 +59564,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  } = props;
 	  return [styles.input, ownerState.size === 'small' && styles.inputSizeSmall, ownerState.multiline && styles.inputMultiline, ownerState.type === 'search' && styles.inputTypeSearch, ownerState.startAdornment && styles.inputAdornedStart, ownerState.endAdornment && styles.inputAdornedEnd, ownerState.hiddenLabel && styles.inputHiddenLabel];
 	};
-	const useUtilityClasses$i = ownerState => {
+	const useUtilityClasses$g = ownerState => {
 	  const {
 	    classes,
 	    color,
@@ -59039,7 +59782,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      type = 'text',
 	      value: valueProp
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$m);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$k);
 	  const value = inputPropsProp.value != null ? inputPropsProp.value : valueProp;
 	  const {
 	    current: isControlled
@@ -59213,7 +59956,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    startAdornment,
 	    type
 	  });
-	  const classes = useUtilityClasses$i(ownerState);
+	  const classes = useUtilityClasses$g(ownerState);
 	  const Root = slots.root || components.Root || InputBaseRoot;
 	  const rootProps = slotProps.root || componentsProps.root || {};
 	  const Input = slots.input || components.Input || InputBaseComponent;
@@ -59501,8 +60244,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const inputClasses = _extends$2({}, inputBaseClasses$1, generateUtilityClasses('MuiInput', ['root', 'underline', 'input']));
 	var inputClasses$1 = inputClasses;
 
-	const _excluded$l = ["disableUnderline", "components", "componentsProps", "fullWidth", "inputComponent", "multiline", "slotProps", "slots", "type"];
-	const useUtilityClasses$h = ownerState => {
+	const _excluded$j = ["disableUnderline", "components", "componentsProps", "fullWidth", "inputComponent", "multiline", "slotProps", "slots", "type"];
+	const useUtilityClasses$f = ownerState => {
 	  const {
 	    classes,
 	    disableUnderline
@@ -59614,8 +60357,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      slots = {},
 	      type = 'text'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$l);
-	  const classes = useUtilityClasses$h(props);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$j);
+	  const classes = useUtilityClasses$f(props);
 	  const ownerState = {
 	    disableUnderline
 	  };
@@ -59837,8 +60580,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const filledInputClasses = _extends$2({}, inputBaseClasses$1, generateUtilityClasses('MuiFilledInput', ['root', 'underline', 'input']));
 	var filledInputClasses$1 = filledInputClasses;
 
-	const _excluded$k = ["disableUnderline", "components", "componentsProps", "fullWidth", "hiddenLabel", "inputComponent", "multiline", "slotProps", "slots", "type"];
-	const useUtilityClasses$g = ownerState => {
+	const _excluded$i = ["disableUnderline", "components", "componentsProps", "fullWidth", "hiddenLabel", "inputComponent", "multiline", "slotProps", "slots", "type"];
+	const useUtilityClasses$e = ownerState => {
 	  const {
 	    classes,
 	    disableUnderline
@@ -60021,14 +60764,14 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      slots = {},
 	      type = 'text'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$k);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$i);
 	  const ownerState = _extends$2({}, props, {
 	    fullWidth,
 	    inputComponent,
 	    multiline,
 	    type
 	  });
-	  const classes = useUtilityClasses$g(props);
+	  const classes = useUtilityClasses$e(props);
 	  const filledInputComponentsProps = {
 	    root: {
 	      ownerState
@@ -60252,7 +60995,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	var FilledInput$1 = FilledInput;
 
 	var _span$1;
-	const _excluded$j = ["children", "classes", "className", "label", "notched"];
+	const _excluded$h = ["children", "classes", "className", "label", "notched"];
 	const NotchedOutlineRoot$1 = styled$1('fieldset')({
 	  textAlign: 'left',
 	  position: 'absolute',
@@ -60325,7 +61068,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      label,
 	      notched
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$j);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$h);
 	  const withLabel = label != null && label !== '';
 	  const ownerState = _extends$2({}, props, {
 	    notched,
@@ -60382,8 +61125,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const outlinedInputClasses = _extends$2({}, inputBaseClasses$1, generateUtilityClasses('MuiOutlinedInput', ['root', 'notchedOutline', 'input']));
 	var outlinedInputClasses$1 = outlinedInputClasses;
 
-	const _excluded$i = ["components", "fullWidth", "inputComponent", "label", "multiline", "notched", "slots", "type"];
-	const useUtilityClasses$f = ownerState => {
+	const _excluded$g = ["components", "fullWidth", "inputComponent", "label", "multiline", "notched", "slots", "type"];
+	const useUtilityClasses$d = ownerState => {
 	  const {
 	    classes
 	  } = ownerState;
@@ -60501,8 +61244,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      slots = {},
 	      type = 'text'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$i);
-	  const classes = useUtilityClasses$f(props);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$g);
+	  const classes = useUtilityClasses$d(props);
 	  const muiFormControl = useFormControl();
 	  const fcs = formControlState({
 	    props,
@@ -60722,8 +61465,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const formLabelClasses = generateUtilityClasses('MuiFormLabel', ['root', 'colorSecondary', 'focused', 'disabled', 'error', 'filled', 'required', 'asterisk']);
 	var formLabelClasses$1 = formLabelClasses;
 
-	const _excluded$h = ["children", "className", "color", "component", "disabled", "error", "filled", "focused", "required"];
-	const useUtilityClasses$e = ownerState => {
+	const _excluded$f = ["children", "className", "color", "component", "disabled", "error", "filled", "focused", "required"];
+	const useUtilityClasses$c = ownerState => {
 	  const {
 	    classes,
 	    color,
@@ -60787,7 +61530,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      className,
 	      component = 'label'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$h);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$f);
 	  const muiFormControl = useFormControl();
 	  const fcs = formControlState({
 	    props,
@@ -60803,7 +61546,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    focused: fcs.focused,
 	    required: fcs.required
 	  });
-	  const classes = useUtilityClasses$e(ownerState);
+	  const classes = useUtilityClasses$c(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsxs(FormLabelRoot, _extends$2({
 	    as: component,
 	    ownerState: ownerState,
@@ -60878,8 +61621,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiInputLabel', ['root', 'focused', 'disabled', 'error', 'required', 'asterisk', 'formControl', 'sizeSmall', 'shrink', 'animated', 'standard', 'filled', 'outlined']);
 
-	const _excluded$g = ["disableAnimation", "margin", "shrink", "variant", "className"];
-	const useUtilityClasses$d = ownerState => {
+	const _excluded$e = ["disableAnimation", "margin", "shrink", "variant", "className"];
+	const useUtilityClasses$b = ownerState => {
 	  const {
 	    classes,
 	    formControl,
@@ -60980,7 +61723,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      shrink: shrinkProp,
 	      className
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$g);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$e);
 	  const muiFormControl = useFormControl();
 	  let shrink = shrinkProp;
 	  if (typeof shrink === 'undefined' && muiFormControl) {
@@ -60999,7 +61742,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    variant: fcs.variant,
 	    required: fcs.required
 	  });
-	  const classes = useUtilityClasses$d(ownerState);
+	  const classes = useUtilityClasses$b(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsx(InputLabelRoot, _extends$2({
 	    "data-shrink": shrink,
 	    ownerState: ownerState,
@@ -61084,8 +61827,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	const nativeSelectClasses = generateUtilityClasses('MuiNativeSelect', ['root', 'select', 'multiple', 'filled', 'outlined', 'standard', 'disabled', 'icon', 'iconOpen', 'iconFilled', 'iconOutlined', 'iconStandard', 'nativeInput', 'error']);
 	var nativeSelectClasses$1 = nativeSelectClasses;
 
-	const _excluded$f = ["className", "disabled", "error", "IconComponent", "inputRef", "variant"];
-	const useUtilityClasses$c = ownerState => {
+	const _excluded$d = ["className", "disabled", "error", "IconComponent", "inputRef", "variant"];
+	const useUtilityClasses$a = ownerState => {
 	  const {
 	    classes,
 	    variant,
@@ -61213,13 +61956,13 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      inputRef,
 	      variant = 'standard'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$f);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$d);
 	  const ownerState = _extends$2({}, props, {
 	    disabled,
 	    variant,
 	    error
 	  });
-	  const classes = useUtilityClasses$c(ownerState);
+	  const classes = useUtilityClasses$a(ownerState);
 	  return /*#__PURE__*/jsxRuntimeExports.jsxs(reactExports.Fragment, {
 	    children: [/*#__PURE__*/jsxRuntimeExports.jsx(NativeSelectSelect, _extends$2({
 	      ownerState: ownerState,
@@ -61298,7 +62041,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	var selectClasses$1 = selectClasses;
 
 	var _span;
-	const _excluded$e = ["aria-describedby", "aria-label", "autoFocus", "autoWidth", "children", "className", "defaultOpen", "defaultValue", "disabled", "displayEmpty", "error", "IconComponent", "inputRef", "labelId", "MenuProps", "multiple", "name", "onBlur", "onChange", "onClose", "onFocus", "onOpen", "open", "readOnly", "renderValue", "SelectDisplayProps", "tabIndex", "type", "value", "variant"];
+	const _excluded$c = ["aria-describedby", "aria-label", "autoFocus", "autoWidth", "children", "className", "defaultOpen", "defaultValue", "disabled", "displayEmpty", "error", "IconComponent", "inputRef", "labelId", "MenuProps", "multiple", "name", "onBlur", "onChange", "onClose", "onFocus", "onOpen", "open", "readOnly", "renderValue", "SelectDisplayProps", "tabIndex", "type", "value", "variant"];
 	const SelectSelect = styled$1('div', {
 	  name: 'MuiSelect',
 	  slot: 'Select',
@@ -61365,7 +62108,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	function isEmpty(display) {
 	  return display == null || typeof display === 'string' && !display.trim();
 	}
-	const useUtilityClasses$b = ownerState => {
+	const useUtilityClasses$9 = ownerState => {
 	  const {
 	    classes,
 	    variant,
@@ -61421,7 +62164,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      value: valueProp,
 	      variant = 'standard'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$e);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$c);
 	  const [value, setValueState] = useControlled({
 	    controlled: valueProp,
 	    default: defaultValue,
@@ -61709,7 +62452,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    open,
 	    error
 	  });
-	  const classes = useUtilityClasses$b(ownerState);
+	  const classes = useUtilityClasses$9(ownerState);
 	  const paperProps = _extends$2({}, MenuProps.PaperProps, (_MenuProps$slotProps = MenuProps.slotProps) == null ? void 0 : _MenuProps$slotProps.paper);
 	  const listboxId = useId();
 	  return /*#__PURE__*/jsxRuntimeExports.jsxs(reactExports.Fragment, {
@@ -61938,9 +62681,9 @@ Please use another name.` : formatMuiErrorMessage(18));
 	  d: "M7 10l5 5 5-5z"
 	}), 'ArrowDropDown');
 
-	const _excluded$d = ["autoWidth", "children", "classes", "className", "defaultOpen", "displayEmpty", "IconComponent", "id", "input", "inputProps", "label", "labelId", "MenuProps", "multiple", "native", "onClose", "onOpen", "open", "renderValue", "SelectDisplayProps", "variant"],
+	const _excluded$b = ["autoWidth", "children", "classes", "className", "defaultOpen", "displayEmpty", "IconComponent", "id", "input", "inputProps", "label", "labelId", "MenuProps", "multiple", "native", "onClose", "onOpen", "open", "renderValue", "SelectDisplayProps", "variant"],
 	  _excluded2$1 = ["root"];
-	const useUtilityClasses$a = ownerState => {
+	const useUtilityClasses$8 = ownerState => {
 	  const {
 	    classes
 	  } = ownerState;
@@ -61983,7 +62726,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      SelectDisplayProps,
 	      variant: variantProp = 'outlined'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$d);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$b);
 	  const inputComponent = native ? NativeSelectInput$1 : SelectInput$1;
 	  const muiFormControl = useFormControl();
 	  const fcs = formControlState({
@@ -61996,7 +62739,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    variant,
 	    classes: classesProp
 	  });
-	  const classes = useUtilityClasses$a(ownerState);
+	  const classes = useUtilityClasses$8(ownerState);
 	  const restOfClasses = _objectWithoutPropertiesLoose$1(classes, _excluded2$1);
 	  const InputComponent = input || {
 	    standard: /*#__PURE__*/jsxRuntimeExports.jsx(StyledInput, {
@@ -62207,13 +62950,13 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	generateUtilityClasses('MuiTextField', ['root']);
 
-	const _excluded$c = ["autoComplete", "autoFocus", "children", "className", "color", "defaultValue", "disabled", "error", "FormHelperTextProps", "fullWidth", "helperText", "id", "InputLabelProps", "inputProps", "InputProps", "inputRef", "label", "maxRows", "minRows", "multiline", "name", "onBlur", "onChange", "onFocus", "placeholder", "required", "rows", "select", "SelectProps", "type", "value", "variant"];
+	const _excluded$a = ["autoComplete", "autoFocus", "children", "className", "color", "defaultValue", "disabled", "error", "FormHelperTextProps", "fullWidth", "helperText", "id", "InputLabelProps", "inputProps", "InputProps", "inputRef", "label", "maxRows", "minRows", "multiline", "name", "onBlur", "onChange", "onFocus", "placeholder", "required", "rows", "select", "SelectProps", "type", "value", "variant"];
 	const variantComponent = {
 	  standard: Input$1,
 	  filled: FilledInput$1,
 	  outlined: OutlinedInput$1
 	};
-	const useUtilityClasses$9 = ownerState => {
+	const useUtilityClasses$7 = ownerState => {
 	  const {
 	    classes
 	  } = ownerState;
@@ -62299,7 +63042,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      value,
 	      variant = 'outlined'
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$c);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$a);
 	  const ownerState = _extends$2({}, props, {
 	    autoFocus,
 	    color,
@@ -62311,7 +63054,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    select,
 	    variant
 	  });
-	  const classes = useUtilityClasses$9(ownerState);
+	  const classes = useUtilityClasses$7(ownerState);
 	  if (process.env.NODE_ENV !== 'production') {
 	    if (select && !children) {
 	      console.error('MUI: `children` must be passed when using the `TextField` component with `select`.');
@@ -62562,103 +63305,6 @@ Please use another name.` : formatMuiErrorMessage(18));
 	} : void 0;
 	var TextField$1 = TextField;
 
-	function getFormGroupUtilityClass(slot) {
-	  return generateUtilityClass('MuiFormGroup', slot);
-	}
-	generateUtilityClasses('MuiFormGroup', ['root', 'row', 'error']);
-
-	const _excluded$b = ["className", "row"];
-	const useUtilityClasses$8 = ownerState => {
-	  const {
-	    classes,
-	    row,
-	    error
-	  } = ownerState;
-	  const slots = {
-	    root: ['root', row && 'row', error && 'error']
-	  };
-	  return composeClasses(slots, getFormGroupUtilityClass, classes);
-	};
-	const FormGroupRoot = styled$1('div', {
-	  name: 'MuiFormGroup',
-	  slot: 'Root',
-	  overridesResolver: (props, styles) => {
-	    const {
-	      ownerState
-	    } = props;
-	    return [styles.root, ownerState.row && styles.row];
-	  }
-	})(({
-	  ownerState
-	}) => _extends$2({
-	  display: 'flex',
-	  flexDirection: 'column',
-	  flexWrap: 'wrap'
-	}, ownerState.row && {
-	  flexDirection: 'row'
-	}));
-
-	/**
-	 * `FormGroup` wraps controls such as `Checkbox` and `Switch`.
-	 * It provides compact row layout.
-	 * For the `Radio`, you should be using the `RadioGroup` component instead of this one.
-	 */
-	const FormGroup = /*#__PURE__*/reactExports.forwardRef(function FormGroup(inProps, ref) {
-	  const props = useThemeProps({
-	    props: inProps,
-	    name: 'MuiFormGroup'
-	  });
-	  const {
-	      className,
-	      row = false
-	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$b);
-	  const muiFormControl = useFormControl();
-	  const fcs = formControlState({
-	    props,
-	    muiFormControl,
-	    states: ['error']
-	  });
-	  const ownerState = _extends$2({}, props, {
-	    row,
-	    error: fcs.error
-	  });
-	  const classes = useUtilityClasses$8(ownerState);
-	  return /*#__PURE__*/jsxRuntimeExports.jsx(FormGroupRoot, _extends$2({
-	    className: clsx(classes.root, className),
-	    ownerState: ownerState,
-	    ref: ref
-	  }, other));
-	});
-	process.env.NODE_ENV !== "production" ? FormGroup.propTypes /* remove-proptypes */ = {
-	  // ----------------------------- Warning --------------------------------
-	  // | These PropTypes are generated from the TypeScript type definitions |
-	  // |     To update them edit the d.ts file and run "yarn proptypes"     |
-	  // ----------------------------------------------------------------------
-	  /**
-	   * The content of the component.
-	   */
-	  children: PropTypes.node,
-	  /**
-	   * Override or extend the styles applied to the component.
-	   */
-	  classes: PropTypes.object,
-	  /**
-	   * @ignore
-	   */
-	  className: PropTypes.string,
-	  /**
-	   * Display group of elements in a compact row.
-	   * @default false
-	   */
-	  row: PropTypes.bool,
-	  /**
-	   * The system prop that allows defining system overrides as well as additional CSS styles.
-	   */
-	  sx: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])), PropTypes.func, PropTypes.object])
-	} : void 0;
-	var FormGroup$1 = FormGroup;
-
 	/**
 	 * @ignore - internal component.
 	 */
@@ -62668,7 +63314,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	}
 	var RadioGroupContext$1 = RadioGroupContext;
 
-	const _excluded$a = ["actions", "children", "defaultValue", "name", "onChange", "value"];
+	const _excluded$9 = ["actions", "children", "defaultValue", "name", "onChange", "value"];
 	const RadioGroup = /*#__PURE__*/reactExports.forwardRef(function RadioGroup(props, ref) {
 	  const {
 	      // private
@@ -62680,7 +63326,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	      onChange,
 	      value: valueProp
 	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$a);
+	    other = _objectWithoutPropertiesLoose$1(props, _excluded$9);
 	  const rootRef = reactExports.useRef(null);
 	  const [value, setValueState] = useControlled({
 	    controlled: valueProp,
@@ -62756,267 +63402,6 @@ Please use another name.` : formatMuiErrorMessage(18));
 	function useRadioGroup() {
 	  return reactExports.useContext(RadioGroupContext$1);
 	}
-
-	function getSwitchBaseUtilityClass(slot) {
-	  return generateUtilityClass('PrivateSwitchBase', slot);
-	}
-	generateUtilityClasses('PrivateSwitchBase', ['root', 'checked', 'disabled', 'input', 'edgeStart', 'edgeEnd']);
-
-	const _excluded$9 = ["autoFocus", "checked", "checkedIcon", "className", "defaultChecked", "disabled", "disableFocusRipple", "edge", "icon", "id", "inputProps", "inputRef", "name", "onBlur", "onChange", "onFocus", "readOnly", "required", "tabIndex", "type", "value"];
-	const useUtilityClasses$7 = ownerState => {
-	  const {
-	    classes,
-	    checked,
-	    disabled,
-	    edge
-	  } = ownerState;
-	  const slots = {
-	    root: ['root', checked && 'checked', disabled && 'disabled', edge && `edge${capitalize(edge)}`],
-	    input: ['input']
-	  };
-	  return composeClasses(slots, getSwitchBaseUtilityClass, classes);
-	};
-	const SwitchBaseRoot = styled$1(ButtonBase$1)(({
-	  ownerState
-	}) => _extends$2({
-	  padding: 9,
-	  borderRadius: '50%'
-	}, ownerState.edge === 'start' && {
-	  marginLeft: ownerState.size === 'small' ? -3 : -12
-	}, ownerState.edge === 'end' && {
-	  marginRight: ownerState.size === 'small' ? -3 : -12
-	}));
-	const SwitchBaseInput = styled$1('input')({
-	  cursor: 'inherit',
-	  position: 'absolute',
-	  opacity: 0,
-	  width: '100%',
-	  height: '100%',
-	  top: 0,
-	  left: 0,
-	  margin: 0,
-	  padding: 0,
-	  zIndex: 1
-	});
-
-	/**
-	 * @ignore - internal component.
-	 */
-	const SwitchBase = /*#__PURE__*/reactExports.forwardRef(function SwitchBase(props, ref) {
-	  const {
-	      autoFocus,
-	      checked: checkedProp,
-	      checkedIcon,
-	      className,
-	      defaultChecked,
-	      disabled: disabledProp,
-	      disableFocusRipple = false,
-	      edge = false,
-	      icon,
-	      id,
-	      inputProps,
-	      inputRef,
-	      name,
-	      onBlur,
-	      onChange,
-	      onFocus,
-	      readOnly,
-	      required = false,
-	      tabIndex,
-	      type,
-	      value
-	    } = props,
-	    other = _objectWithoutPropertiesLoose$1(props, _excluded$9);
-	  const [checked, setCheckedState] = useControlled({
-	    controlled: checkedProp,
-	    default: Boolean(defaultChecked),
-	    name: 'SwitchBase',
-	    state: 'checked'
-	  });
-	  const muiFormControl = useFormControl();
-	  const handleFocus = event => {
-	    if (onFocus) {
-	      onFocus(event);
-	    }
-	    if (muiFormControl && muiFormControl.onFocus) {
-	      muiFormControl.onFocus(event);
-	    }
-	  };
-	  const handleBlur = event => {
-	    if (onBlur) {
-	      onBlur(event);
-	    }
-	    if (muiFormControl && muiFormControl.onBlur) {
-	      muiFormControl.onBlur(event);
-	    }
-	  };
-	  const handleInputChange = event => {
-	    // Workaround for https://github.com/facebook/react/issues/9023
-	    if (event.nativeEvent.defaultPrevented) {
-	      return;
-	    }
-	    const newChecked = event.target.checked;
-	    setCheckedState(newChecked);
-	    if (onChange) {
-	      // TODO v6: remove the second argument.
-	      onChange(event, newChecked);
-	    }
-	  };
-	  let disabled = disabledProp;
-	  if (muiFormControl) {
-	    if (typeof disabled === 'undefined') {
-	      disabled = muiFormControl.disabled;
-	    }
-	  }
-	  const hasLabelFor = type === 'checkbox' || type === 'radio';
-	  const ownerState = _extends$2({}, props, {
-	    checked,
-	    disabled,
-	    disableFocusRipple,
-	    edge
-	  });
-	  const classes = useUtilityClasses$7(ownerState);
-	  return /*#__PURE__*/jsxRuntimeExports.jsxs(SwitchBaseRoot, _extends$2({
-	    component: "span",
-	    className: clsx(classes.root, className),
-	    centerRipple: true,
-	    focusRipple: !disableFocusRipple,
-	    disabled: disabled,
-	    tabIndex: null,
-	    role: undefined,
-	    onFocus: handleFocus,
-	    onBlur: handleBlur,
-	    ownerState: ownerState,
-	    ref: ref
-	  }, other, {
-	    children: [/*#__PURE__*/jsxRuntimeExports.jsx(SwitchBaseInput, _extends$2({
-	      autoFocus: autoFocus,
-	      checked: checkedProp,
-	      defaultChecked: defaultChecked,
-	      className: classes.input,
-	      disabled: disabled,
-	      id: hasLabelFor ? id : undefined,
-	      name: name,
-	      onChange: handleInputChange,
-	      readOnly: readOnly,
-	      ref: inputRef,
-	      required: required,
-	      ownerState: ownerState,
-	      tabIndex: tabIndex,
-	      type: type
-	    }, type === 'checkbox' && value === undefined ? {} : {
-	      value
-	    }, inputProps)), checked ? checkedIcon : icon]
-	  }));
-	});
-
-	// NB: If changed, please update Checkbox, Switch and Radio
-	// so that the API documentation is updated.
-	process.env.NODE_ENV !== "production" ? SwitchBase.propTypes = {
-	  /**
-	   * If `true`, the `input` element is focused during the first mount.
-	   */
-	  autoFocus: PropTypes.bool,
-	  /**
-	   * If `true`, the component is checked.
-	   */
-	  checked: PropTypes.bool,
-	  /**
-	   * The icon to display when the component is checked.
-	   */
-	  checkedIcon: PropTypes.node.isRequired,
-	  /**
-	   * Override or extend the styles applied to the component.
-	   * See [CSS API](#css) below for more details.
-	   */
-	  classes: PropTypes.object,
-	  /**
-	   * @ignore
-	   */
-	  className: PropTypes.string,
-	  /**
-	   * @ignore
-	   */
-	  defaultChecked: PropTypes.bool,
-	  /**
-	   * If `true`, the component is disabled.
-	   */
-	  disabled: PropTypes.bool,
-	  /**
-	   * If `true`, the  keyboard focus ripple is disabled.
-	   * @default false
-	   */
-	  disableFocusRipple: PropTypes.bool,
-	  /**
-	   * If given, uses a negative margin to counteract the padding on one
-	   * side (this is often helpful for aligning the left or right
-	   * side of the icon with content above or below, without ruining the border
-	   * size and shape).
-	   * @default false
-	   */
-	  edge: PropTypes.oneOf(['end', 'start', false]),
-	  /**
-	   * The icon to display when the component is unchecked.
-	   */
-	  icon: PropTypes.node.isRequired,
-	  /**
-	   * The id of the `input` element.
-	   */
-	  id: PropTypes.string,
-	  /**
-	   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
-	   */
-	  inputProps: PropTypes.object,
-	  /**
-	   * Pass a ref to the `input` element.
-	   */
-	  inputRef: refType$1,
-	  /*
-	   * @ignore
-	   */
-	  name: PropTypes.string,
-	  /**
-	   * @ignore
-	   */
-	  onBlur: PropTypes.func,
-	  /**
-	   * Callback fired when the state is changed.
-	   *
-	   * @param {object} event The event source of the callback.
-	   * You can pull out the new checked state by accessing `event.target.checked` (boolean).
-	   */
-	  onChange: PropTypes.func,
-	  /**
-	   * @ignore
-	   */
-	  onFocus: PropTypes.func,
-	  /**
-	   * It prevents the user from changing the value of the field
-	   * (not from interacting with the field).
-	   */
-	  readOnly: PropTypes.bool,
-	  /**
-	   * If `true`, the `input` element is required.
-	   */
-	  required: PropTypes.bool,
-	  /**
-	   * The system prop that allows defining system overrides as well as additional CSS styles.
-	   */
-	  sx: PropTypes.object,
-	  /**
-	   * @ignore
-	   */
-	  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-	  /**
-	   * The input component prop `type`.
-	   */
-	  type: PropTypes.string.isRequired,
-	  /**
-	   * The value of the component.
-	   */
-	  value: PropTypes.any
-	} : void 0;
-	var SwitchBase$1 = SwitchBase;
 
 	var RadioButtonUncheckedIcon = createSvgIcon$1( /*#__PURE__*/jsxRuntimeExports.jsx("path", {
 	  d: "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
@@ -65525,7 +65910,7 @@ Please use another name.` : formatMuiErrorMessage(18));
 	    href: apiData.menus.account.resetPasswordUrl
 	  }, COURSEFLOW_APP.strings.password_reset), /*#__PURE__*/React.createElement(MenuItem$1, {
 	    component: "a",
-	    href: apiData.menus.account.profileUrl
+	    href: apiData.menus.account.notificationsSettingsUrls
 	  }, COURSEFLOW_APP.strings.notification_settings), /*#__PURE__*/React.createElement(Divider$1, null), /*#__PURE__*/React.createElement(MenuItem$1, {
 	    component: "a",
 	    href: apiData.menus.account.daliteUrl
@@ -104265,6 +104650,8 @@ Please use another name.` : formatMuiErrorMessage(18));
 	     *******************************************************/
 	    case 'notifications':
 	      return /*#__PURE__*/React.createElement(NotificationsPage, null);
+	    case 'notificationsSettings':
+	      return /*#__PURE__*/React.createElement(NotificationsSettingsPage, null);
 	    case 'profileSettings':
 	      return /*#__PURE__*/React.createElement(ProfileSettingsPage, null);
 

--- a/course_flow/static/course_flow/js/react/src/Components/Pages/Notifications/index.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/Pages/Notifications/index.jsx
@@ -16,10 +16,9 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import DotsIcon from '@mui/icons-material/MoreHoriz'
 
-import useApi from '../../../hooks/useApi'
+import { OuterContentWrap } from '@cfModule/mui/helper'
+import useApi from '@cfModule/hooks/useApi'
 import { API_POST } from '@XMLHTTP/PostFunctions'
-import { OuterContentWrap } from '../../../mui/helper'
-import { DATA_ACTIONS } from '@XMLHTTP/common'
 
 const NotificationsWrap = styled(Box)({})
 

--- a/course_flow/static/course_flow/js/react/src/Components/Pages/NotificationsSettings/index.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/Pages/NotificationsSettings/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from 'react'
+import React, { useReducer } from 'react'
 import { styled } from '@mui/material/styles'
 import Box from '@mui/material/Box'
 import FormGroup from '@mui/material/FormGroup'
@@ -6,7 +6,6 @@ import FormControlLabel from '@mui/material/FormControlLabel'
 import Switch from '@mui/material/Switch'
 import Typography from '@mui/material/Typography'
 import { OuterContentWrap } from '@cfModule/mui/helper'
-import useApi from '@cfModule/hooks/useApi'
 import { API_POST } from '@XMLHTTP/PostFunctions'
 
 const PageTitle = styled(Box)(({ theme }) => ({
@@ -23,68 +22,36 @@ const PageTitle = styled(Box)(({ theme }) => ({
 // with various different controls
 function reducer(state, action) {
   switch (action.type) {
-    case 'SET_INITIAL_STATE':
-      return {
-        ...state,
-        ...action.payload
-      }
     case 'SET_UPDATES':
       return {
         ...state,
-        updates: action.value
+        notifications: action.value
       }
   }
 
   return state
 }
 
-const NotificationsSettingsPage = () => {
+const NotificationsSettingsPage = ({ formData }) => {
   const [state, dispatch] = useReducer(reducer, {
-    updates: false
+    notifications: formData.receiveNotifications
   })
-
-  const [apiData, loading, error] = useApi(
-    COURSEFLOW_APP.config.json_api_paths.update_notifications_settings
-  )
-
-  // after the apiData is loaded in, set it as state so it can be used internally
-  useEffect(() => {
-    if (!loading) {
-      dispatch({
-        type: 'SET_INITIAL_STATE',
-        payload: apiData
-      })
-    }
-  }, [loading])
-
-  if (loading || error) {
-    return null
-  }
 
   function onUpdatesSwitchChange(e) {
     const newState = {
       ...state,
-      updates: !state.updates
+      notifications: !state.notifications
     }
 
     // post to the appropriate URL
     API_POST(
       COURSEFLOW_APP.config.json_api_paths.update_notifications_settings,
       newState
-    ).then((response) => {
-      console.log(
-        'API_POST\n',
-        newState,
-        '\nto\n',
-        COURSEFLOW_APP.config.json_api_paths.update_notifications_settings,
-        '\ngot\n',
-        response
-      )
-
+    ).then(() => {
       // and if successful, dispatch the action to update local state
       dispatch({
         type: 'SET_UPDATES',
-        value: !state.updates
+        value: newState.notifications
       })
     })
   }
@@ -100,7 +67,10 @@ const NotificationsSettingsPage = () => {
       <FormGroup>
         <FormControlLabel
           control={
-            <Switch checked={state.updates} onChange={onUpdatesSwitchChange} />
+            <Switch
+              checked={state.notifications}
+              onChange={onUpdatesSwitchChange}
+            />
           }
           label={COURSEFLOW_APP.strings.product_updates_agree}
         />

--- a/course_flow/static/course_flow/js/react/src/Components/Pages/NotificationsSettings/index.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/Pages/NotificationsSettings/index.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useReducer } from 'react'
+import { styled } from '@mui/material/styles'
+import Box from '@mui/material/Box'
+import FormGroup from '@mui/material/FormGroup'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Switch from '@mui/material/Switch'
+import Typography from '@mui/material/Typography'
+import { OuterContentWrap } from '@cfModule/mui/helper'
+import useApi from '@cfModule/hooks/useApi'
+import { API_POST } from '@XMLHTTP/PostFunctions'
+
+const PageTitle = styled(Box)(({ theme }) => ({
+  paddingTop: theme.spacing(4),
+  paddingBottom: theme.spacing(6),
+  '& .MuiTypography-h1': {
+    color: 'currentColor',
+    fontWeight: 400,
+    fontSize: '34px'
+  }
+}))
+
+// NOTE: Using reducer here in anitipation of more complex settings page
+// with various different controls
+function reducer(state, action) {
+  switch (action.type) {
+    case 'SET_INITIAL_STATE':
+      return {
+        ...state,
+        ...action.payload
+      }
+    case 'SET_UPDATES':
+      return {
+        ...state,
+        updates: action.value
+      }
+  }
+
+  return state
+}
+
+const NotificationsSettingsPage = () => {
+  const [state, dispatch] = useReducer(reducer, {
+    updates: false
+  })
+
+  const [apiData, loading, error] = useApi(
+    COURSEFLOW_APP.config.json_api_paths.update_notifications_settings
+  )
+
+  // after the apiData is loaded in, set it as state so it can be used internally
+  useEffect(() => {
+    if (!loading) {
+      dispatch({
+        type: 'SET_INITIAL_STATE',
+        payload: apiData
+      })
+    }
+  }, [loading])
+
+  if (loading || error) {
+    return null
+  }
+
+  function onUpdatesSwitchChange(e) {
+    const newState = {
+      ...state,
+      updates: !state.updates
+    }
+
+    // post to the appropriate URL
+    API_POST(
+      COURSEFLOW_APP.config.json_api_paths.update_notifications_settings,
+      newState
+    ).then((response) => {
+      console.log(
+        'API_POST\n',
+        newState,
+        '\nto\n',
+        COURSEFLOW_APP.config.json_api_paths.update_notifications_settings,
+        '\ngot\n',
+        response
+      )
+
+      // and if successful, dispatch the action to update local state
+      dispatch({
+        type: 'SET_UPDATES',
+        value: !state.updates
+      })
+    })
+  }
+
+  return (
+    <OuterContentWrap narrow>
+      <PageTitle>
+        <Typography variant="h1">
+          {COURSEFLOW_APP.strings.notification_settings}
+        </Typography>
+      </PageTitle>
+
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Switch checked={state.updates} onChange={onUpdatesSwitchChange} />
+          }
+          label={COURSEFLOW_APP.strings.product_updates_agree}
+        />
+      </FormGroup>
+    </OuterContentWrap>
+  )
+}
+
+export default NotificationsSettingsPage

--- a/course_flow/static/course_flow/js/react/src/Components/Pages/ProfileSettings/index.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/Pages/ProfileSettings/index.jsx
@@ -12,9 +12,9 @@ import Radio from '@mui/material/Radio'
 import Button from '@mui/material/Button'
 import Snackbar from '@mui/material/Snackbar'
 import Typography from '@mui/material/Typography'
-import useApi from '../../../hooks/useApi'
+import useApi from '@cfModule/hooks/useApi'
+import { OuterContentWrap } from '@cfModule/mui/helper'
 import { API_POST } from '@XMLHTTP/PostFunctions'
-import { OuterContentWrap } from '../../../mui/helper'
 
 const PageTitle = styled(Box)(({ theme }) => ({
   paddingTop: theme.spacing(4),

--- a/course_flow/static/course_flow/js/react/src/Components/Pages/ProfileSettings/index.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/Pages/ProfileSettings/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { styled } from '@mui/material/styles'
 import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
@@ -12,7 +12,6 @@ import Radio from '@mui/material/Radio'
 import Button from '@mui/material/Button'
 import Snackbar from '@mui/material/Snackbar'
 import Typography from '@mui/material/Typography'
-import useApi from '@cfModule/hooks/useApi'
 import { OuterContentWrap } from '@cfModule/mui/helper'
 import { API_POST } from '@XMLHTTP/PostFunctions'
 
@@ -32,24 +31,14 @@ const FormWrap = styled(Box)({
   }
 })
 
-const ProfileSettingsPage = () => {
+const ProfileSettingsPage = ({ formData }) => {
+  const [state, setState] = useState(formData)
   const [errors, setErrors] = useState({})
-  const [formFields, setFormFields] = useState(null)
   const [showSnackbar, setShowSnackbar] = useState(false)
-  const [apiData, loading, error] = useApi(
-    COURSEFLOW_APP.config.json_api_paths.update_profile
-  )
-
-  // after the apiData is loaded in, set it as state so it can be used internally
-  useEffect(() => {
-    if (!loading) {
-      setFormFields(apiData.fields)
-    }
-  }, [loading])
 
   function onFormSubmit() {
     const formData = {}
-    formFields.map((field) => (formData[field.name] = field.value))
+    state.map((field) => (formData[field.name] = field.value))
 
     API_POST(COURSEFLOW_APP.config.json_api_paths.update_profile, formData)
       .then(() => setShowSnackbar(true))
@@ -60,12 +49,8 @@ const ProfileSettingsPage = () => {
     setShowSnackbar(false)
   }
 
-  if (loading || error || !formFields) {
-    return null
-  }
-
   // loop through all the fields and generate appropriate MUI input element
-  const inputFields = formFields.map((field, idx) => {
+  const inputFields = state.map((field, idx) => {
     const hasError = errors[field.name]
     const errorText = hasError && errors[field.name][0]
 
@@ -83,12 +68,12 @@ const ProfileSettingsPage = () => {
                 error={hasError}
                 helperText={errorText}
                 onChange={(e) => {
-                  const newFieldsState = [...formFields]
+                  const newFieldsState = [...state]
                   newFieldsState[idx].value = e.target.value
                   const newErrors = { ...errors }
                   delete newErrors[field.name]
                   setErrors(newErrors)
-                  setFormFields(newFieldsState)
+                  setState(newFieldsState)
                 }}
               />
             </FormControl>
@@ -104,12 +89,12 @@ const ProfileSettingsPage = () => {
                 value={field.value}
                 name={field.name}
                 onChange={(e) => {
-                  const newFieldsState = [...formFields]
+                  const newFieldsState = [...state]
                   newFieldsState[idx].value = e.target.value
                   const newErrors = { ...errors }
                   delete newErrors[field.name]
                   setErrors(newErrors)
-                  setFormFields(newFieldsState)
+                  setState(newFieldsState)
                 }}
               >
                 {field.options.map((option, idy) => (

--- a/course_flow/static/course_flow/js/react/src/Components/components/Layout/TopBar.jsx
+++ b/course_flow/static/course_flow/js/react/src/Components/components/Layout/TopBar.jsx
@@ -250,7 +250,10 @@ const TopBar = () => {
       <MenuItem component="a" href={apiData.menus.account.resetPasswordUrl}>
         {COURSEFLOW_APP.strings.password_reset}
       </MenuItem>
-      <MenuItem component="a" href={apiData.menus.account.profileUrl}>
+      <MenuItem
+        component="a"
+        href={apiData.menus.account.notificationsSettingsUrls}
+      >
         {COURSEFLOW_APP.strings.notification_settings}
       </MenuItem>
       <Divider />

--- a/course_flow/static/course_flow/js/react/src/entry/scripts-redesign.js
+++ b/course_flow/static/course_flow/js/react/src/entry/scripts-redesign.js
@@ -116,7 +116,7 @@ const getAppComponent = () => {
     case 'notificationsSettings':
       return <NotificationsSettingsPage {...COURSEFLOW_APP.contextData} />
     case 'profileSettings':
-      return <ProfileSettingsPage />
+      return <ProfileSettingsPage {...COURSEFLOW_APP.contextData} />
 
     /*******************************************************
      * LIVE

--- a/course_flow/static/course_flow/js/react/src/entry/scripts-redesign.js
+++ b/course_flow/static/course_flow/js/react/src/entry/scripts-redesign.js
@@ -114,7 +114,7 @@ const getAppComponent = () => {
     case 'notifications':
       return <NotificationsPage />
     case 'notificationsSettings':
-      return <NotificationsSettingsPage />
+      return <NotificationsSettingsPage {...COURSEFLOW_APP.contextData} />
     case 'profileSettings':
       return <ProfileSettingsPage />
 

--- a/course_flow/static/course_flow/js/react/src/entry/scripts-redesign.js
+++ b/course_flow/static/course_flow/js/react/src/entry/scripts-redesign.js
@@ -16,6 +16,7 @@ import createCache from '@emotion/cache'
 
 // pages/views/templates
 import NotificationsPage from '../Components/Pages/Notifications'
+import NotificationsSettingsPage from '../Components/Pages/NotificationsSettings'
 import ProfileSettingsPage from '../Components/Pages/ProfileSettings'
 
 // components
@@ -112,6 +113,8 @@ const getAppComponent = () => {
      *******************************************************/
     case 'notifications':
       return <NotificationsPage />
+    case 'notificationsSettings':
+      return <NotificationsSettingsPage />
     case 'profileSettings':
       return <ProfileSettingsPage />
 

--- a/course_flow/static/course_flow/scss/base_style.scss
+++ b/course_flow/static/course_flow/scss/base_style.scss
@@ -684,7 +684,7 @@ h3.big-space {
 }
 
 .left-panel-extra {
-  overflow-y: overlay;
+  overflow-y: auto;
 }
 
 .title-image {
@@ -822,7 +822,7 @@ h3.big-space {
 .home-tabs > div {
   width: 100%;
   box-sizing: border-box;
-  overflow-y: overlay;
+  overflow-y: auto;
 }
 
 .saltise-menu-container {
@@ -831,7 +831,7 @@ h3.big-space {
   background: $color-white;
   padding: 50px;
   box-sizing: border-box;
-  overflow: overlay;
+  overflow: auto;
 }
 
 .menu-create {
@@ -1039,7 +1039,7 @@ h3.big-space {
   margin-bottom: 2px;
   white-space: pre-wrap;
   max-height: 140px;
-  overflow-y: overlay;
+  overflow-y: auto;
 }
 
 .workflow-for-menu .workflow-description.collapsible-text {
@@ -1360,7 +1360,7 @@ h3.big-space {
 }
 
 .explore-menu .explore-preview {
-  overflow-x: overlay;
+  overflow-x: auto;
 }
 
 .explore-menu .explore-main {
@@ -1705,13 +1705,13 @@ h3.big-space {
 
 .message-wrap .home-tabs {
   height: calc(100% - 100px);
-  overflow-y: overlay;
+  overflow-y: auto;
 }
 
 .message-wrap {
   width: 100%;
   height: 100%;
-  overflow-y: overlay;
+  overflow-y: auto;
   padding: 20px;
   padding-left: 40px;
   padding-right: 40px;
@@ -1890,7 +1890,7 @@ text {
 }
 
 .body-wrapper {
-  overflow: overlay;
+  overflow: auto;
   flex-grow: 1;
   height: 100%;
   position: relative;

--- a/course_flow/static/course_flow/scss/base_style.scss
+++ b/course_flow/static/course_flow/scss/base_style.scss
@@ -1894,6 +1894,7 @@ text {
   flex-grow: 1;
   height: 100%;
   position: relative;
+  background-color: $color-white;
 }
 
 .body-wrapper.printing {

--- a/course_flow/static/course_flow/scss/workflow_styles.scss
+++ b/course_flow/static/course_flow/scss/workflow_styles.scss
@@ -1607,7 +1607,7 @@ div:hover > .mouseover-container-bypass > .mouseover-actions {
   border: 1px solid $color-primary-green;
   background: $color-white;
   z-index: 7;
-  overflow: overlay;
+  overflow: auto;
   padding: 5px;
   font-size: 12px;
   box-sizing: border-box;
@@ -1972,7 +1972,7 @@ circle.mouseover {
 }
 
 .right-panel-inner {
-  overflow-y: overlay;
+  overflow-y: auto;
   display: inline-block;
   padding: 20px;
   box-sizing: border-box;
@@ -2265,7 +2265,7 @@ circle.mouseover {
   background: $color-white;
   height: 100%;
   padding: 20px;
-  overflow: overlay;
+  overflow: auto;
   vertical-align: top;
 }
 

--- a/course_flow/templates/course_flow/base/config_js.html
+++ b/course_flow/templates/course_flow/base/config_js.html
@@ -126,6 +126,7 @@
       get_sidebar: "{% url 'course_flow:json-api-get-sidebar' %}",
       update_profile: "{% url 'course_flow:json-api-get-post-update-profile-settings' %}",
       get_notifications_page: "{% url 'course_flow:json-api-get-notifications-page' %}",
+      update_notifications_settings: "{% url 'course_flow:json-api-get-post-notifications-settings' %}",
       mark_all_notifications_as_read: "{% url 'course_flow:json-api-post-mark-all-notifications-as-read' %}",
       delete_notification: "{% url 'course_flow:json-api-post-delete-notification' %}",
     },
@@ -148,6 +149,7 @@
       "{% trans 'Hi there! Would you like to receive emails about updates to  CourseFlow? You can always change your mind by viewing your profile.' %}",
     unsupported_device:
       "{% trans 'Your device is not supported. Please use a laptop or desktop for the best experience.' %}",
+    product_updates_agree: "{% trans 'I want to receive product updates emails' %}",
     notifications: "{% trans 'Notifications' %}",
     home: "{% trans 'Home' %}",
     my_library: "{% trans 'My library' %}",

--- a/course_flow/templates/course_flow/base/react_renderer.html
+++ b/course_flow/templates/course_flow/base/react_renderer.html
@@ -30,6 +30,10 @@
       COURSEFLOW_APP.contextData = DTOContextData
       break;
     }
+    case 'profileSettings': {
+      COURSEFLOW_APP.contextData = DTOContextData
+      break;
+    }
     case 'home': {
       COURSEFLOW_APP.contextData = DTOContextData
       makeActiveSidebarID = '#panel-home'

--- a/course_flow/templates/course_flow/base/react_renderer.html
+++ b/course_flow/templates/course_flow/base/react_renderer.html
@@ -1,7 +1,6 @@
 <script nonce="{{ request.csp_nonce }}">
   COURSEFLOW_APP.path_id = "{{ path_id }}";
   const DTOContextData = {{ contextData | safe }};
-  let localContextData
   let makeActiveSidebarID = null
 
   switch (COURSEFLOW_APP.path_id) {
@@ -14,7 +13,7 @@
           program: "{% url 'course_flow:program-create' projectPk=object.pk %}"
         }
       {% endif %}
-      makeActiveSidebarID = "#project" + localContextData.project_data.id
+      makeActiveSidebarID = "#project" + DTOContextData.project_data.id
       break;
     }
     case 'favorites': {
@@ -25,6 +24,10 @@
     case 'library': {
       COURSEFLOW_APP.contextData = DTOContextData
       makeActiveSidebarID = '#panel-my-library'
+      break;
+    }
+    case 'notificationsSettings': {
+      COURSEFLOW_APP.contextData = DTOContextData
       break;
     }
     case 'home': {

--- a/course_flow/templates/course_flow/react/notifications_settings.html
+++ b/course_flow/templates/course_flow/react/notifications_settings.html
@@ -1,0 +1,13 @@
+{% extends "course_flow/base.html" %}
+
+{% load static i18n %}
+{% load course_flow_templatetags %}
+{% csrf_token %}
+
+{% block title %}
+  {% trans title %} - CourseFlow
+{% endblock %}
+
+{% block react_scripts %}
+  {% include "course_flow/base/react_renderer.html" %}
+{% endblock %}

--- a/course_flow/urls.py
+++ b/course_flow/urls.py
@@ -85,6 +85,11 @@ def course_flow_patterns():
             name="user-notifications",
         ),
         path(
+            "user/notifications-settings/",
+            views.user.notifications_settings_view,
+            name="user-notifications-settings",
+        ),
+        path(
             "project/create/",
             views.ProjectCreateView.as_view(),
             name="project-create",
@@ -132,6 +137,11 @@ def course_flow_patterns():
             "json-api-get-post-update-profile-settings/",
             views.json_api.update.json_api_get_post_profile_settings,
             name="json-api-get-post-update-profile-settings",
+        ),
+        path(
+            "json-api-get-post-notifications-settings/",
+            views.json_api.update.json_api_get_post_notifications_settings,
+            name="json-api-get-post-notifications-settings",
         ),
         path(
             "comments/add/",

--- a/course_flow/views/html/user.py
+++ b/course_flow/views/html/user.py
@@ -1,8 +1,10 @@
+import json
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from course_flow.decorators import ajax_login_required
+from course_flow.models import CourseFlowUser
 
 @ajax_login_required
 def logout_view(request):
@@ -22,10 +24,15 @@ def notifications_view(request):
 
 @login_required
 def notifications_settings_view(request):
+    user = CourseFlowUser.objects.filter(user=request.user).first()
     context = {
         "title": "Notifications Settings",
         "path_id": "notificationsSettings",
-        "contextData": {}
+        "contextData": json.dumps({
+            "formData": {
+                "receiveNotifications": user.notifications
+            }
+        })
     }
     return render(request, "course_flow/react/notifications_settings.html", context)
 

--- a/course_flow/views/html/user.py
+++ b/course_flow/views/html/user.py
@@ -5,6 +5,9 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from course_flow.decorators import ajax_login_required
 from course_flow.models import CourseFlowUser
+from course_flow.forms import ProfileSettings
+from course_flow.serializers import FormFieldsSerializer
+
 
 @ajax_login_required
 def logout_view(request):
@@ -39,9 +42,21 @@ def notifications_settings_view(request):
 
 @login_required
 def profile_settings_view(request):
+    user = CourseFlowUser.objects.filter(user=request.user).first()
+    form = ProfileSettings(
+        {
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "language": user.language,
+        }
+    )
+
     context = {
         "title": "Profile Settings",
         "path_id": "profileSettings",
-        "contextData": {}
+        "contextData": json.dumps({
+            "formData": FormFieldsSerializer(form).prepare_fields()
+        })
     }
+
     return render(request, "course_flow/react/profile_settings.html", context)

--- a/course_flow/views/html/user.py
+++ b/course_flow/views/html/user.py
@@ -21,6 +21,16 @@ def notifications_view(request):
 
 
 @login_required
+def notifications_settings_view(request):
+    context = {
+        "title": "Notifications Settings",
+        "path_id": "notificationsSettings",
+        "contextData": {}
+    }
+    return render(request, "course_flow/react/notifications_settings.html", context)
+
+
+@login_required
 def profile_settings_view(request):
     context = {
         "title": "Profile Settings",

--- a/course_flow/views/json_api/menu.py
+++ b/course_flow/views/json_api/menu.py
@@ -82,6 +82,7 @@ def json_api_get_top_bar(request: HttpRequest) -> JsonResponse:
                     "projectUrl": reverse("course_flow:project-create"),
                 },
                 "account": {
+                    "notificationsSettingsUrls": reverse("course_flow:user-notifications-settings"),
                     "profileUrl": reverse("course_flow:user-update"),
                     "resetPasswordUrl": course_flow_password_change_url(),
                     "daliteUrl": course_flow_return_url(),

--- a/course_flow/views/json_api/update.py
+++ b/course_flow/views/json_api/update.py
@@ -680,6 +680,16 @@ def json_api_get_post_profile_settings(request: HttpRequest) -> JsonResponse:
     )
 
 
+@login_required
+def json_api_get_post_notifications_settings(request: HttpRequest) -> JsonResponse:
+    if request.method == "POST":
+        return JsonResponse({"action": "posted"})
+
+    return JsonResponse(
+        {"fields": "brooo"}
+    )
+
+
 # A helper function to set the linked workflow.
 # Do not call if you are duplicating the parent workflow,
 # that gets taken care of in another manner.

--- a/course_flow/views/json_api/update.py
+++ b/course_flow/views/json_api/update.py
@@ -20,7 +20,10 @@ from course_flow.duplication_functions import (
     fast_create_strategy,
     fast_duplicate_workflow,
 )
-from course_flow.forms import ProfileSettings
+from course_flow.forms import (
+    ProfileSettings,
+    NotificationsSettings
+)
 from course_flow.models import (
     Column,
     CourseFlowUser,
@@ -667,7 +670,7 @@ def json_api_get_post_profile_settings(request: HttpRequest) -> JsonResponse:
 
     # otherwise, the method is GET in which case we're simply returning
     # the JSON for all the inputs for the Profile Settings page (form)
-    profile_form = ProfileSettings(
+    form = ProfileSettings(
         {
             "first_name": user.first_name,
             "last_name": user.last_name,
@@ -676,17 +679,30 @@ def json_api_get_post_profile_settings(request: HttpRequest) -> JsonResponse:
     )
 
     return JsonResponse(
-        {"fields": FormFieldsSerializer(profile_form).prepare_fields()}
+        {"fields": FormFieldsSerializer(form).prepare_fields()}
     )
 
 
 @login_required
 def json_api_get_post_notifications_settings(request: HttpRequest) -> JsonResponse:
+    user = CourseFlowUser.objects.filter(user=request.user).first()
+
     if request.method == "POST":
-        return JsonResponse({"action": "posted"})
+        # on POST, instantiate the form with the JSON params and the model instance
+        form = NotificationsSettings(json.loads(request.body), instance=user)
+
+        # if the form is valid, save it and return a success response
+        if form.is_valid():
+            form.save()
+            return JsonResponse({"action": "posted"})
+
+        # otherwise, return the errors so UI can display errors accordingly
+        return JsonResponse({"action": "error", "errors": form.errors})
+
+    form = NotificationsSettings({"notifications": user.notifications})
 
     return JsonResponse(
-        {"fields": "brooo"}
+        {"fields": FormFieldsSerializer(form).prepare_fields()}
     )
 
 


### PR DESCRIPTION
- Create the Notifications Settings page as a separate React component
- Tweak FormFieldsSerializer class data iterator to properly resolve lazy gettext instances and proxy objects (so that `json.dumps` doesn't break trying to serialize proxy objects later on n the execution flow)
- Minor CSS style tweaks
- Tweak Profile Settings page to initially set state from props, instead of firing a separate GET request to get the initial data / form fields to be able to render the form on the UI end (applying the same methods as for the Notifications Settings page)